### PR TITLE
Add Makefile with cmd for previewing rendered specs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+PREVIEW_SRC_DEST=/tmp/site_preview
+
+preview:
+	mkdir -p $(PREVIEW_SRC_DEST)
+	rm -rf $(PREVIEW_SRC_DEST)
+	git clone https://github.com/scientific-python/scientific-python.org $(PREVIEW_SRC_DEST)
+	git -C $(PREVIEW_SRC_DEST) submodule update --init
+	rm -rf $(PREVIEW_SRC_DEST)/content/specs/*
+	cp -r * $(PREVIEW_SRC_DEST)/content/specs
+	cd $(PREVIEW_SRC_DEST) && hugo server --disableFastRender
+
+clean:
+	rm -rf $(PREVIEW_SRC_DEST)
+
+.PHONY: clean preview


### PR DESCRIPTION
This (or something like it) might be a nice tool for authors/reviewers of specs.

Adds a Makefile with a `preview` command that grabs the latest scientific-python.org site, embeds the local specs in it, and serves it locally. This is a nice tool to have to be able to preview changes to the specs locally prior to opening a PR.

This implementation isn't necessarily the best, but I think something along these lines would be nice to include in the repo.