### PR TITLE
Test SPEC adoption

### DIFF
--- a/core-projects/scikit-image.md
+++ b/core-projects/scikit-image.md
@@ -1,0 +1,12 @@
+---
+title: "scikit-image"
+draft: false
+homepage: https://scikit-image.org
+repository: https://github.com/scikit-image/scikit-image
+pypi: https://pypi.org/project/scikit-image
+libraries-io: https://libraries.io/pypi/scikit-image
+license: https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt
+license-type: 3-clause BSD
+adopters: stefanv
+---
+

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -5,7 +5,7 @@ draft: false
 author:
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
 discussion: https://github.com/scientific-python/specs/discussions/15
-adopted-by:
+adopted-by: networkx, scikit-image
 ---
 
 # Description


### PR DESCRIPTION
Things to fix.

- [x] The ``Adopted By`` column should have a comma separated list of core projects that have adopted the SPEC appearing as links to their ``core-project`` pages:
![screenshot](https://user-images.githubusercontent.com/123428/105549022-46b47680-5cb5-11eb-8931-c7629a58fcc8.png)

- [x] The  ``Adopted By`` field on SPEC pages should have the ``core-projects`` appear as links to their ``core-project`` pages:
![screenshot](https://user-images.githubusercontent.com/123428/105549303-a6ab1d00-5cb5-11eb-8042-a45d372ab38d.png)

- [ ]  It would be nice for the ``core-projects`` to always appear in the same order loosely based on importance (rather than date or alphabetical order of something.  Here are three ideas about how to do that:
  - add a order field to each ``core-project`` and sort the list based on that field
  - prepend a number to each project page (ie., ``10-numpy.md``, ``20-scipy.md``, etc. and sort by filename.
  - add ``order.txt`` file and sort according to order in file
 
- [x] Remove dead code from ``layouts/partials/post_meta/project_meta.html``.  I think I copied-and-pasted this based on some other files and it looks like I don't know what I am doing.  For example, given that we removed the ``projects`` directory, I don't think this line is used:
  ```
  a href="{{ relref . (printf "/projects/%s" $el) }}">{{ $el }}</a>
  ```
  I suspect this file has more nonsense and needs to be revised.