### PR TITLE
Notes from the latest metaspec iteration

### DIFF
--- a/meta-spec-0000.md
+++ b/meta-spec-0000.md
@@ -82,9 +82,10 @@ necessary infrastructure required by other projects wishing to adopt the SPEC.
 
 # Implementation
 
-Any community member can propose a new SPEC by making making a pull request to
-the [SPEC repository](https://github.com/scientific-python/specs).
-However, we highly recommended that you first do one or more of the following:
+Each SPEC focuses on a single key proposal, recommendation, or idea for
+coordinating projects in the scientific Python ecosystem.
+Any community member can submit a new SPEC.
+However, we highly recommended that you **first** do one or more of the following:
 
 1. discuss the idea in at least one project in the ecosystem,
 2. discuss the idea with at least one other member of the ecosystem,
@@ -92,28 +93,18 @@ However, we highly recommended that you first do one or more of the following:
    [`specs` discussion forum](https://discuss.scientific-python.org/c/specs/ideas/9),
 4. create a minimal, proof of concept prototype.
 
-To get feedback from the larger community, we also recommend creating a new
-[discussion topic](https://discuss.scientific-python.org/c/specs/ideas/9)—under
-the `Proposed` subcategory of the `SPECs`
-category—as early in the process as possible.
-The discussion will be linked to the new SPEC using the `discussion`
-field in the SPEC header.
-Each new discussion should focus on a single key proposal or new idea for
-coordinating projects in the scientific Python ecosystem.
+Contributors must adhere to our
+[Code of Conduct]({{< relref "/about/code_of_conduct.md" >}}).
 
-Contributors must adhere to our [Code of Conduct]({{< relref
-"/about/code_of_conduct.md" >}}).
+## New SPEC
 
-## New SPECs
-
-Creating a new SPEC requires:
-
-1. making a pull request with a new SPEC document (Markdown file), and
-2. starting a related discussion.
+Submitting a new SPEC requires making a pull request to the 
+[SPEC repository](https://github.com/scientific-python/specs).
+with a new SPEC document.
 
 To create a new SPEC document, use the `quickstart.py` script.
-Located at the top-level of the [SPEC
-repository](https://github.com/scientific-python/specs),
+Located at the top-level of the
+[SPEC repository](https://github.com/scientific-python/specs),
 the script will ask you a few questions and then create a new file
 appropriately named with a basic template for you to complete.
 
@@ -208,10 +199,9 @@ endorsed-by:
 {{< / highlight >}}
 <!-- prettier-ignore-end -->
 
-While it is recommended that you create a new discussion before creating the PR,
-you can also leave the discussion number blank.
-Before the PR is merged, you will be asked to verify that you've created a
-new discussion and that the `discussion` field is correct.
+Before the PR is merged, you will be asked to create a new discussion (if you haven't already)
+and to verify that the `discussion` field is correct.
+Leave the `draft` field as is and the `endorsed-by` field empty.
 
 Once the SPEC is in reasonable shape, file a pull request against the
 [scientific-python/specs](https://github.com/scientific-python/specs)

--- a/meta-spec-0000.md
+++ b/meta-spec-0000.md
@@ -98,8 +98,8 @@ Contributors must adhere to our
 
 ## New SPEC
 
-Submitting a new SPEC requires making a pull request to the 
-[SPEC repository](https://github.com/scientific-python/specs).
+Submitting a new SPEC requires making a pull request to the
+[SPEC repository](https://github.com/scientific-python/specs)
 with a new SPEC document.
 
 To create a new SPEC document, use the `quickstart.py` script.

--- a/meta-spec-0000.md
+++ b/meta-spec-0000.md
@@ -26,9 +26,8 @@ Projects decide for themselves whether to adopt any given SPEC—often, this
 would be through team consensus.
 A SPEC may not be a good fit for every single project, and thus there is no
 expectation that all SPECs must be adopted by all projects.
-Different SPECs may even recommend differing approaches to the same problem.
-In this case, some projects may adopt one of the competing SPECS,
-while some projects adopt the other one.
+Different SPECs may even recommend differing approaches to the same problem for
+the sake of discussion and consensus-building among the projects.
 SPECs may also propose only certain projects prototype a SPEC before
 encouraging other projects to consider adopting the SPEC.
 
@@ -95,7 +94,7 @@ However, we highly recommended that you first do one or more of the following:
 
 To get feedback from the larger community, we also recommend creating a new
 [discussion topic](https://discuss.scientific-python.org/c/specs/ideas/9)—under
-the `Accepted` subcategory of the `SPECs`
+the `Proposed` subcategory of the `SPECs`
 category—as early in the process as possible.
 The discussion will be linked to the new SPEC using the `discussion`
 field in the SPEC header.

--- a/meta-spec-0001.md
+++ b/meta-spec-0001.md
@@ -22,8 +22,8 @@ They do, however,
 - determine which new ideas are assigned a SPEC number as described in
   [MetaSPEC 0 — Purpose and Process]({{< relref "/specs/meta-spec-0000.md" >}}),
 - approve changes to the MetaSPECs (i.e., SPECs about SPECs), and
-- serve as a communication channel to and from their projects as well
-  as the larger ecosystem.
+- serve as a communication channel to and from projects they contribute to as
+  well as the larger ecosystem.
 
 ## Steering Committee
 
@@ -106,7 +106,7 @@ They do, however,
 
 # Implementation
 
-To accept a SPEC proposal (i.e., to assign it a SPEC number and merge the PR)
+To accept a SPEC (i.e., to assign it a SPEC number and merge the PR)
 requires two members of the SSC to approve and no members objecting.
 Since the role of the SSC is to mainly ensure that SPEC proposals are
 appropriate, objections should be rare.

--- a/meta-spec-0002.md
+++ b/meta-spec-0002.md
@@ -103,7 +103,7 @@ to have greater influence on the Core Projects and larger ecosystem.
 
 # Implementation
 
-The [SSC]({{< relref "/specs/meta-spec-0001.md" >}})) maintains the list of
+The [SSC]({{< relref "/specs/meta-spec-0001.md" >}}) maintains the list of
 Core Projects.
 
 ## What are the characteristics of a Core Project?


### PR DESCRIPTION
The main takeaway I had was that the distinction between "accepted", "adopted", and "endorsed" is *much* more clear now. The glossary in metaspec 0000 definitely helps in this regard, but also it feels like the terms are now used consistently throughout the metaspecs.

I've made some wording changes in this PR, but mostly just so that I can highlight specific parts of the text for discussion.