### PR TITLE
Notes from metaspec0 version 5403d5b

### DIFF
--- a/meta-spec-0000.md
+++ b/meta-spec-0000.md
@@ -70,7 +70,7 @@ Accepting a SPEC means that is is assigned a number,
 included in the [SPEC listing]({{< relref "/spec_overview.md" >}}),
 and linked to a
 [`specs` discussion topic](https://discuss.scientific-python.org/c/specs/accepted/15).
-It typically is accepted once there is some agreement that the SPEC
+The main criterion for acceptance is some agreement among the SSC that the SPEC
 describes a useful proposal, recommendation, or idea for coordinating projects.
 Often, implementation details will need to be developed and negotiated with
 projects and will necessarily develop and evolve after the SPEC is accepted.

--- a/meta-spec-0000.md
+++ b/meta-spec-0000.md
@@ -74,7 +74,7 @@ The main criterion for acceptance is some agreement among the SSC that the SPEC
 describes a useful proposal, recommendation, or idea for coordinating projects.
 Often, implementation details will need to be developed and negotiated with
 projects and will necessarily develop and evolve after the SPEC is accepted.
-Accept SPECs are marked as a `draft document` until there is a consensus
+Accepted SPECs are marked as a `draft document` until there is a consensus
 that it ready for widespread project adoption.
 
 Adopted

--- a/meta-spec-0000.md
+++ b/meta-spec-0000.md
@@ -48,7 +48,7 @@ documentation, testing, and so forth.
 
 Core Projects
 : The [Core Projects]({{< relref "/specs/meta-spec-0002.md" >}}) are
-a small set of mature, community developed project widely used in
+a small set of mature, community developed projects widely used in
 scientific research and by other packages in the ecosystem.
 
 SSC


### PR DESCRIPTION
A few minor typos and one wording suggestion. There is more detail on the process in this version, which I think is an improvement as it provides a clearer picture of what the general approval-adoption-endoresement process looks like, and who is responsible for what. A couple points that might be worth emphasizing more:
 - The SSC's role is primarily involved with *Accepting* SPECs, i.e. *Acceptance* of a SPEC depends on the SSC (and community discussion), but *Adoption* is up to individual projects and *Endorsement* is the purview of Core Projects. I think this is already pretty clear especially in the new section that highlights each of these terms, but could be emphasized a bit more in e.g. the `Implementation` section.
 - Similarly, it may be worth stating that *acceptance of a spec is not a guarantee that it will be adopted*. Acceptance means that the SSC thinks the proposal is reasonable and relevant to scientific Python projects. This point is made clear in the last section ("Once a SPEC is accepted, the hard work begins"), but could be stated explicitly higher up in the document as well.