### PR TITLE
Notes from latest process readthrough

### DIFF
--- a/purpose-and-process/index.md
+++ b/purpose-and-process/index.md
@@ -67,7 +67,7 @@ the entire ecosystem.
 
 SPEC Document
 : A **SPEC document** provides operational guidelines for projects in the ecosystem and
-helps coordinate the ecosystem and to provide a more unified experience for users.
+helps coordinate the ecosystem to provide a more unified experience for users.
 These documents are developed collaboratively with the Core Projects and other interested
 ecosystem projects and community members.
 

--- a/purpose-and-process/index.md
+++ b/purpose-and-process/index.md
@@ -146,8 +146,7 @@ Any project in the ecosystem is welcome to adopt a SPEC at any point.
 However, it may make sense to wait until a SPEC is endorsed by several Core Projects.
 This ensures that the SPEC has been vetted and deemed stable enough for widespread adoption.
 Once a SPEC is endorsed by several Core Projects it may still evolve, but the
-barrier for modifying the SPEC will increase substantially once it is endorsed by several
-Core Projects (since all endorsing projects would need to agree to changes).
+barrier for modifying the SPEC will increase substantially (since all endorsing projects would need to agree to changes).
 Projects that adopt a SPEC early should engage in the collaborative process
 leading to the SPEC being endorsed by the Core Projects.
 Each SPEC describes what adopting it means in its _Ecosystem Adoption_ section.

--- a/purpose-and-process/index.md
+++ b/purpose-and-process/index.md
@@ -66,8 +66,8 @@ with the Core Projects, as well as community members and projects across
 the entire ecosystem.
 
 SPEC Document
-: A **SPEC document** provides operational guidelines for projects in the ecosystem and
-helps coordinate the ecosystem to provide a more unified experience for users.
+: A **SPEC document** provides operational guidelines for projects in the ecosystem and helps
+coordinate the ecosystem to provide a more unified experience for users and developers.
 These documents are developed collaboratively with the Core Projects and other interested
 ecosystem projects and community members.
 
@@ -112,6 +112,10 @@ by doing one or more of the following:
 2. discuss the idea with at least one other member of the ecosystem, or
 3. create a minimal, proof of concept prototype.
 
+There are several stages that a SPEC undergoes over the course of its development and implementation:
+**Acceptance**, **Endorsement**, and **Adoption**.
+These stages are described below.
+
 ## Accept
 
 The Steering Committee will accept the new SPEC document based on the quality of the proposal
@@ -145,8 +149,9 @@ work in existing projects.
 Any project in the ecosystem is welcome to adopt a SPEC at any point.
 However, it may make sense to wait until a SPEC is endorsed by several Core Projects.
 This ensures that the SPEC has been vetted and deemed stable enough for widespread adoption.
-Once a SPEC is endorsed by several Core Projects it may still evolve, but the
-barrier for modifying the SPEC will increase substantially (since all endorsing projects would need to agree to changes).
+Once a SPEC is endorsed by several Core Projects it may still evolve,
+but the barrier for modifying the SPEC will increase substantially
+(since all endorsing projects would need to agree to changes).
 Projects that adopt a SPEC early should engage in the collaborative process
 leading to the SPEC being endorsed by the Core Projects.
 Each SPEC describes what adopting it means in its _Ecosystem Adoption_ section.

--- a/purpose-and-process/index.md
+++ b/purpose-and-process/index.md
@@ -103,7 +103,7 @@ appropriately named with a basic template for you to complete.
 Once the SPEC is in reasonable shape, file a pull request against the
 [SPEC repository](https://github.com/scientific-python/specs).
 
-A good SPEC proposal focuses on a single key proposal, recommendation, or idea for
+A good SPEC proposal focuses on a single key recommendation or idea for
 coordinating projects in the scientific Python ecosystem.
 Before proposing a SPEC, we highly recommended that you first **vet the idea**
 by doing one or more of the following:


### PR DESCRIPTION
I left a few wording suggestions, but overall I think that this iteration of the document has a tighter focus (which is good). One of the biggest improvements IMO is the removal/footnoting of some of the details (e.g. the SPEC template, which took up the most space in the previous iteration), which helps keep attention on the high-level ideas.

One thing that might help new readers is a short preamble before the subsections that introduce the SPEC statuses/procedures (i.e. Accept, Endorse, and Adopt). For example, a short blurb just before the `Accept` heading along the lines of:

 > There are several stages that a SPEC undergoes over the course of its development and implementation: **Acceptance**, **Endorsement**, and **Adoption**. These stages are described below.