### PR TITLE
Review of changes in #74

### DIFF
--- a/core-projects/_index.md
+++ b/core-projects/_index.md
@@ -23,7 +23,7 @@ Core Projects.
 Core Projects endorse SPEC documents.
 During the endorsement stage of the SPEC process, Core Project contributors
 propose, discuss, and review SPEC documents with the goal of developing
-an implementation plan that all the Core Projects will adopt and endorse.
+a coherent implementation plan suitable for all the Core Projects.
 Often SPECs are coauthored by contributors from several Core Projects as well
 as other community members (e.g., contributors to other ecosystem projects).
 


### PR DESCRIPTION
The text added in #74 better illustrates the relationship between the Steering Committee and the Core Projects, though IMO this is a difficult task without going into too much detail. I think the docs as currently constituted do a good job of describing the distinct roles of the Steering Council and Core Projects. Overall, I think the purpose and process doc still does the best job of illustrating these concepts, as it's difficult (at least for me) to focus on one or the other without keeping a clear picture of the entire process in mind.

My sense is that, at this stage, it's best not to try to spell out the relationship between the various SPEC bodies too concretely.