### PR TITLE
Add initial core project contacts

### DIFF
--- a/core-projects/ipython.md
+++ b/core-projects/ipython.md
@@ -8,5 +8,5 @@ pypi: https://pypi.org/project/ipython
 libraries-io: https://libraries.io/pypi/ipython
 license: https://github.com/ipython/ipython/blob/master/LICENSE
 license-type: 3-clause BSD
-adopters: Carreau
+contact: Carreau
 ---

--- a/core-projects/matplotlib.md
+++ b/core-projects/matplotlib.md
@@ -6,7 +6,7 @@ homepage: https://matplotlib.org
 repository: https://github.com/matplotlib/matplotlib
 pypi: https://pypi.org/project/matplotlib
 libraries-io: https://libraries.io/pypi/matplotlib
-license: https://matplotlib.org/3.3.3/users/license.html
+license: https://matplotlib.org/stable/users/license.html
 license-type: Matplotlib license
-adopters:
+contact: QuLogic
 ---

--- a/core-projects/networkx.md
+++ b/core-projects/networkx.md
@@ -8,5 +8,5 @@ pypi: https://pypi.org/project/networkx
 libraries-io: https://libraries.io/pypi/networkx
 license: https://networkx.org/documentation/stable/license.html
 license-type: 3-clause BSD
-adopters:
+contact: rossbar
 ---

--- a/core-projects/numpy.md
+++ b/core-projects/numpy.md
@@ -6,7 +6,7 @@ homepage: https://numpy.org
 repository: https://github.com/numpy/numpy
 pypi: https://pypi.org/project/numpy
 libraries-io: https://libraries.io/pypi/numpy
-license: https://github.com/numpy/numpy/blob/master/LICENSE.txt
+license: https://github.com/numpy/numpy/blob/main/LICENSE.txt
 license-type: 3-clause BSD
-adopters:
+contact: melissawm
 ---

--- a/core-projects/pandas.md
+++ b/core-projects/pandas.md
@@ -1,0 +1,12 @@
+---
+title: "pandas"
+draft: true
+avatar: https://avatars.githubusercontent.com/u/21206976
+homepage: https://pandas.pydata.org/
+repository: https://github.com/pandas-dev/pandas
+pypi: https://pypi.org/project/pandas
+libraries-io: https://libraries.io/pypi/pandas
+license: https://github.com/pandas-dev/pandas/blob/master/LICENSE
+license-type: 3-clause BSD
+contact: jorisvandenbossche
+---

--- a/core-projects/register.py
+++ b/core-projects/register.py
@@ -21,9 +21,9 @@ repository = prompt(
     "Repository", default=f"https://github.com/{project_lower}/{project_lower}"
 )
 pypi = prompt("PyPI page", default=f"https://pypi.org/project/{project_lower}")
-license = prompt("License URL", default=f"{repository}/blob/master/LICENSE.txt")
+license = prompt("License URL", default=f"{repository}/blob/main/LICENSE.txt")
 license_type = prompt("License", default="3-clause BSD")
-adopters = prompt("List the GitHub handles of developers who can adopt SPECs")
+contact = prompt("List the GitHub handles of developers to contact about SPECs")
 
 filename = f"{project.lower()}.md"
 text = f"""---
@@ -36,7 +36,7 @@ pypi: {pypi}
 libraries-io: https://libraries.io/pypi/{pypi.split("/")[-1]}
 license: {license}
 license-type: {license_type}
-adopters: {adopters}
+contact: {contact}
 ---
 """
 

--- a/core-projects/scikit-image.md
+++ b/core-projects/scikit-image.md
@@ -6,7 +6,7 @@ homepage: https://scikit-image.org
 repository: https://github.com/scikit-image/scikit-image
 pypi: https://pypi.org/project/scikit-image
 libraries-io: https://libraries.io/pypi/scikit-image
-license: https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt
+license: https://github.com/scikit-image/scikit-image/blob/main/LICENSE.txt
 license-type: 3-clause BSD
-adopters: jarrodmillman
+contact: jni
 ---

--- a/core-projects/scikit-learn.md
+++ b/core-projects/scikit-learn.md
@@ -8,5 +8,5 @@ pypi: https://pypi.org/project/scikit-learn
 libraries-io: https://libraries.io/pypi/scikit-learn
 license: https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
 license-type: 3-clause BSD
-adopters: jarrodmillman
+contact: bsipocz
 ---

--- a/core-projects/scipy.md
+++ b/core-projects/scipy.md
@@ -8,5 +8,5 @@ pypi: https://pypi.org/project/scipy
 libraries-io: https://libraries.io/pypi/scipy
 license: https://github.com/scipy/scipy/blob/master/LICENSE.txt
 license-type: 3-clause BSD
-adopters:
+contact: rgommers
 ---


### PR DESCRIPTION
@QuLogic @rossbar @melissawm @jorisvandenbossche @jni @rgommers @Carreau Please approve this if you are prepared to do the following:

0. Find "your core project" by finding the changed file containing your handle.
1. Once the draft site is  deployed (around 5/17), share the site with "your core project".
2. Ask "your core project" to review the SPEC process documents paying close attention to the Core Project document.
3. Ask "your core project" whether they are willing to be a Core Project in the SPEC process.
4. If  "your core project" agrees, make a PR changing `draft: true` to ` draft: false` in "your core project" file.

Once we set the `draft: false`  for all the initial Core Projects, we will talk more about what this role entails and we will add people to the `contact:` fields for the Core Projects.  Basically, the main responsibility is to be a conduit between the SPECs and "your core project". Letting the Core Projects know about relevant SPECs, and helping ensure Core Project endorsements are correct.