### PR TITLE
Update lazy loading SPEC history

### DIFF
--- a/spec-0001.md
+++ b/spec-0001.md
@@ -91,14 +91,14 @@ As an example, we will show how to set up lazy importing for `skimage.filters`.
 In the library's main `__init__.py`, specify which submodules are lazily loaded:
 
 ```python
-__all__ = [
+submodules = [
     ...
     'filters',
     ...
 ]
 
 from .util.lazy import install_lazy
-__getattr__, __dir__, _ = install_lazy(__name__, __all__)
+__getattr__, __dir__, _ = install_lazy(__name__, submodules)
 ```
 
 Then, in each submodule's `__init__.py` (in this case, `filters/__init__.py`), specify which functions are to be loaded from where:

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -4,6 +4,7 @@ date: 2020-12-17
 draft: true
 author:
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
+  - "Jon Crall <jon.crall@kitware.com>"
 discussion: https://discuss.scientific-python.org/t/spec-1-lazy-loading-for-submodules/25
 endorsed-by:
 ---

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -21,7 +21,11 @@ sp.linalg.eig(...)
 
 This was convenient: it had the simplicity of a flat namespace, but with the organization of a nested one.
 However, there was one drawback: importing submodules, especially large ones, introduced unacceptable slowdowns.
-To address the problem, most libraries stopped importing submodules and relied on documentation to tell users which submodules to import.
+
+For a while, SciPy had a lazy loading mechanism called `PackageLoader`.
+It was eventually dropped, because it failed frequently and in confusing ways—especially when used with interactive prompts.
+
+Thereafter, most libraries stopped importing submodules and relied on documentation to tell users which submodules to import.
 
 Commonly, code now reads:
 

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -196,7 +196,7 @@ functions:
 Ultimately, we hope that lazy importing will become part of Python itself, but the developers have indicated that this is highly unlikely [^cannon].
 In the mean time, we now have the necessary mechanisms to implement it ourselves.
 
-[^cannon]: Cannon B., private communications, 7 January 2021.
+[^cannon]: Cannon B., personal communication, 7 January 2021.
 
 ## Core Project Endorsement
 

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -61,10 +61,10 @@ For example, it allows the following behavior:
 import skimage as ski  # cheap operation; does not load submodules
 
 ski.filters  # cheap operation; loads the filters submodule, but not
-                 # any of its submodules or functions
+             # any of its submodules or functions
 
 ski.filters.gaussian(...)  # loads the file in which gaussian is implemented
-                           # and calls the function
+                           # and calls that function
 
 ```
 
@@ -106,10 +106,10 @@ Then, in each submodule's `__init__.py` (in this case, `filters/__init__.py`), s
 ```python
 from ..util import lazy
 
-__getattr__, __dir__, __all__ = lazy.install_lazy(
+__getattr__, __dir__, __all__ = lazy.install(
     __name__,
     submodules=['rank']
-    submod_funcs={
+    submod_attrs={
         '_gaussian': ['gaussian', 'difference_of_gaussians'],
         'edges': ['sobel', 'sobel_h', 'sobel_v',
                   'scharr', 'scharr_h', 'scharr_v',
@@ -121,14 +121,28 @@ __getattr__, __dir__, __all__ = lazy.install_lazy(
 )
 ```
 
-The submodule is loaded only once it is accessed:
+The above would be equivalent to:
+
+```python
+from . import rank
+from ._gaussian import gaussian, difference_of_gaussians
+from .edges import (sobel, sobel_h, sobel_v,
+                    scharr, scharr_h, scharr_v,
+                    prewitt, prewitt_h, prewitt_v,
+                    roberts, roberts_pos_diag, roberts_neg_diag,
+                    laplace,
+                    farid, farid_h, farid_v)
+```
+
+The difference being that the submodule is loaded only once it is accessed:
 
 ```python
 import skimage
-dir(skimage.filters)
+dir(skimage.filters)  # This works as usual
 ```
 
-Furthermore, the functions inside of the submodule are loaded only once they are needed:
+Furthermore, the functions inside of the submodule are loaded only
+once they are needed:
 
 ```python
 import skimage
@@ -139,15 +153,23 @@ skimage.filters.gaussian(...)  # Lazy load `gaussian` from
 skimage.filters.rank.mean_bilateral(...)  # Loaded once `rank` is accessed
 ```
 
+One disadvantage is that erroneous or missing imports no longer fail immediately.
+During development and testing, the `EAGER_IMPORT` environment variable can be set to disable lazy loading, so that errors like these can be spotted.
+
+#### External libraries
+
+The `lazy.install_lazy` function is an alternative to setting up package internal imports.
+We also provide `lazy.load` so that projects can lazily import external libraries:
+
+```python
+linalg = lazy.load('scipy.linalg')  # `linalg` will only be loaded when accessed
+```
+
 # Implementation
 
-<!--
-Discuss how this would be implemented.
--->
+Currently, a work-in-progress implementation lives in [this pull request to scikit-image](https://github.com/scikit-image/scikit-image/pull/5101)—specifically, inside of `lazy.py`.
 
-Currently, a test implementation lives in [this pull request to scikit-image](https://github.com/scikit-image/scikit-image/pull/5101)—specifically, inside of [`lazy.py`](https://github.com/scikit-image/scikit-image/blob/f5727872efec270d643dd2c281b6f245b03ff937/skimage/util/lazy.py).
-
-At this point, there exists an prototype of lazy loading, and we're showing it to the community to uncover design flaws, discover improvements, and solicit suggestions on APIs.
+At this point, there exists a prototype of lazy loading, and we're showing it to the community to uncover design flaws, discover improvements, and solicit suggestions on APIs.
 
 Once a lazy import interface is implemented, other interesting options become available.
 For example, instead of specifying sub-submodules and functions the way we do above, one could do this in YAML files:
@@ -171,7 +193,7 @@ functions:
 ...
 ```
 
-Ultimately, we hope that lazy importing will become part of Python itself.
+Ultimately, we hope that lazy importing will become part of Python itself, but the developers have indicated that this is unlikely in the near future.
 In the mean time, we now have the necessary mechanisms to implement it ourselves.
 
 ## Core Project Endorsement

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -97,8 +97,8 @@ submodules = [
     ...
 ]
 
-from .util.lazy import install_lazy
-__getattr__, __dir__, _ = install_lazy(__name__, submodules)
+from .util import lazy
+__getattr__, __dir__, _ = lazy.attach(__name__, submodules)
 ```
 
 Then, in each submodule's `__init__.py` (in this case, `filters/__init__.py`), specify which functions are to be loaded from where:
@@ -106,7 +106,7 @@ Then, in each submodule's `__init__.py` (in this case, `filters/__init__.py`), s
 ```python
 from ..util import lazy
 
-__getattr__, __dir__, __all__ = lazy.install(
+__getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submodules=['rank']
     submod_attrs={
@@ -158,7 +158,7 @@ During development and testing, the `EAGER_IMPORT` environment variable can be s
 
 #### External libraries
 
-The `lazy.install_lazy` function is an alternative to setting up package internal imports.
+The `lazy.attach` function is an alternative to setting up package internal imports.
 We also provide `lazy.load` so that projects can lazily import external libraries:
 
 ```python

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -5,6 +5,7 @@ draft: true
 author:
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
   - "Jon Crall <jon.crall@kitware.com>"
+  - "Dan Schult <dschult@colgate.edu>"
 discussion: https://discuss.scientific-python.org/t/spec-1-lazy-loading-for-submodules/25
 endorsed-by:
 ---

--- a/spec-0001.md
+++ b/spec-0001.md
@@ -169,7 +169,7 @@ linalg = lazy.load('scipy.linalg')  # `linalg` will only be loaded when accessed
 
 Currently, a work-in-progress implementation lives in [this pull request to scikit-image](https://github.com/scikit-image/scikit-image/pull/5101)—specifically, inside of `lazy.py`.
 
-At this point, there exists a prototype of lazy loading, and we're showing it to the community to uncover design flaws, discover improvements, and solicit suggestions on APIs.
+At this point, there exists a prototype of lazy loading, and we're showing it to the community to uncover design flaws, discover improvements, and solicit suggestions on APIs. The prototype implementation has been adapted for use in [napari](https://github.com/napari/napari/pull/2816) and [NetworkX](https://github.com/networkx/networkx/pull/4909).
 
 Once a lazy import interface is implemented, other interesting options become available.
 For example, instead of specifying sub-submodules and functions the way we do above, one could do this in YAML files:
@@ -193,8 +193,10 @@ functions:
 ...
 ```
 
-Ultimately, we hope that lazy importing will become part of Python itself, but the developers have indicated that this is unlikely in the near future.
+Ultimately, we hope that lazy importing will become part of Python itself, but the developers have indicated that this is highly unlikely [^cannon].
 In the mean time, we now have the necessary mechanisms to implement it ourselves.
+
+[^cannon]: Cannon B., private communications, 7 January 2021.
 
 ## Core Project Endorsement
 


### PR DESCRIPTION
This started from input by @rkern on https://discuss.scientific-python.org/t/spec-1-lazy-loading-for-submodules/25/7

It also now includes updates to the authors list, and updates the text to match the scikit-image implementation at https://github.com/scikit-image/scikit-image/pull/5101