### PR TITLE
Matplotlib agrees to be a core project.

### DIFF
--- a/core-projects/matplotlib.md
+++ b/core-projects/matplotlib.md
@@ -1,6 +1,6 @@
 ---
 title: "Matplotlib"
-draft: true
+draft: false
 avatar: https://avatars.githubusercontent.com/u/215947
 homepage: https://matplotlib.org
 repository: https://github.com/matplotlib/matplotlib


### PR DESCRIPTION
@tacaswell @efiring @dopplershift @timhoffm as we discussed during the Matplotlib developer meeting a while back, this PR indicates that Matplotlib will participate in the SPEC process as a Core Project.

Please approve or thumbs up this PR to confirm.