### PR TITLE
Fix download link for versions.py

### DIFF
--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -114,4 +114,4 @@ Discuss what it means for a project to adopt this SPEC.
 
 - Code to generate support and drop schedule tables:
 
-{{< readcode file="spec-0000/versions.py" lang="python" >}}
+{{< readcode file="versions.py" lang="python" >}}


### PR DESCRIPTION
The download link wasn't working before.  It makes sense to have all resources for a SPEC as a page bundle.