### PR TITLE
Restructure draft accessibility SPEC

### DIFF
--- a/spec-0003/index.md
+++ b/spec-0003/index.md
@@ -17,28 +17,18 @@ If relevant, include examples of how the new functionality would be used,
 intended use-cases, and pseudo-code illustrating its use.
 -->
 
-Accessibility is about making the world accessible to the full range of human experience, which includes disabilities.
-For example, the physical world can be made more accessible for wheelchair users by having more buildings with ramps.
-Not only should the physical world be accessible, but the digital world as well.
+[Accessibility](https://en.wikipedia.org/wiki/Accessibility) is building things that are fully usable for people with disabilities. [There are many reasons to prioritize accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/#important)), including ethical, user experience, and legal motivations. Accessibility is also a long-recommended web standard (via [WCAG](https://www.w3.org/TR/WCAG/)).
 
-More and more people are accessing the world digitally.
-Access to the internet is a human right.[citation for UN].
-With access to the internet, people can access vital information, such as education [citation for various country laws to access education] or their banking information.
+Scientific Python communities and their projects need to be accessible and inclusive of disabled people. This SPEC is an agreement between projects to 
 
-People with disabilities access the internet as well.
-Blind users can access text on websites with assistive technology such as a screen-reader, which verbally reads text out loud.
-Thus assistive technology empower disabled people to live autonomous lives.
+1. Actively make their work more accessible from software to documentation to community and more. 
+2. Adopt global accessibility guidelines and Scientific Python-specific recommendations as is relevant per project.
+3. Investigate accessibility solutions where they find gaps in existing recommendations (especially for use cases specific to this ecosystem).
+4. Share accessibility knowledge and efforts across projects whenever possible. 
 
-An accessible world allows people with disabilities to not only access information, but also communicate and create.
-Helen Keller’s access to Braille, another form of assistive technology, allowed her to read about the world.
-She used Braille to communicate with others who were Deaf-Blind.
-It also allowed her to publish her experiences [citation for Story of My Life] and advocate for the Deaf-Blind community to the general public.
+## Community
 
-Accessibility benefits everyone.
-For example, captions for videos benefit not only Deaf viewers with complete hearing loss, but also viewers with partial hearing loss due to age.
-Captions also benefit viewers who cannot play audio out loud, such as in a quiet environment or if they have broken speakers.
-[citation to range of disabilities and situational disability].
-Thus accessibility benefits not just “a few disabled people”[a] but all people.
+At the time of writing, accessibility is not a regular consideration in many Scientific Python projects. Many projects may have a handful of people who have accessibility knowledge or are interested in accquiring more, but may not be able to reach critical mass on a per-project basis. Connecting Scientific Python community members focused on accessibility will provide a boon for individuals, projects, and the ecosystem at large. 
 
 ## Implementation
 
@@ -46,8 +36,27 @@ Thus accessibility benefits not just “a few disabled people”[a] but all peop
 Discuss how this would be implemented.
 -->
 
-A full description of the implementation is being written [here](https://github.com/scientific-python/accessibility.scientific-python.org).
-You can also view a [rendered version of that documentation](https://accessibility.scientific-python.org).
+### Global accessibility guidelines
+
+There are accessibility guidelines that extend beyond the Scientific Python ecosystem; we respect those first and foremost. This includes
+
+- [Web Content Accessibility Guidelines (W3C)](https://www.w3.org/TR/WCAG/)
+
+Please note that in many cases guidelines serve as a foundation for accessibility efforts. They are by no means the limit of what is needed to create enjoyably accessible work.
+
+### Scientific Python recommendations
+
+For cases where ecosystem-specific recommendations are needed or examples of accessibility within the ecosystem are helpful, we also provide a list of resources designed to support the needs of our community.
+
+#### Existing recommendations
+
+- [Image descriptions (including alt text)](https://accessibility.scientific-python.org/reference.html)
+
+#### Future recommendations
+
+This may include recommendations that are in progress or have been requested by the community but not yet begun.
+
+- Example item (status)
 
 ### Core Project Endorsement
 

--- a/spec-0003/index.md
+++ b/spec-0003/index.md
@@ -28,7 +28,9 @@ Scientific Python communities and their projects need to be accessible and inclu
 
 ## Community
 
-At the time of writing, accessibility is not a regular consideration in many Scientific Python projects. Many projects may have a handful of people who have accessibility knowledge or are interested in accquiring more, but may not be able to reach critical mass on a per-project basis. Connecting Scientific Python community members focused on accessibility will provide a boon for individuals, projects, and the ecosystem at large. 
+At the time of writing, accessibility is not a regular consideration in many Scientific Python projects. Many projects may have a handful of people who have accessibility knowledge or are interested in acquiring more, but may not be able to reach critical mass on a per-project basis. Connecting Scientific Python community members focused on accessibility will provide a boon for individuals, projects, and the ecosystem at large. 
+
+If you are interested in this effort, [join us now](accessibility.scientific-python.org/community.html)!
 
 ## Implementation
 
@@ -48,6 +50,7 @@ Please note that in many cases guidelines serve as a foundation for accessibilit
 
 For cases where ecosystem-specific recommendations are needed or examples of accessibility within the ecosystem are helpful, we also provide a list of resources designed to support the needs of our community.
 
+If you would like to add, edit or suggest new recommendations, join the community at [accessibility.scientific-python.org](accessibility.scientific-python.org/community.html)
 #### Existing recommendations
 
 - [Image descriptions (including alt text)](https://accessibility.scientific-python.org/reference.html)

--- a/spec-0003/index.md
+++ b/spec-0003/index.md
@@ -10,13 +10,6 @@ endorsed-by:
 
 ## Description
 
-<!--
-Briefly and clearly describe the proposal.
-Explain the general need and the advantages of this specific proposal.
-If relevant, include examples of how the new functionality would be used,
-intended use-cases, and pseudo-code illustrating its use.
--->
-
 [Accessibility](https://en.wikipedia.org/wiki/Accessibility) is building things that are fully usable for people with disabilities. [There are many reasons to prioritize accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/#important)), including ethical, user experience, and legal motivations. Accessibility is also a long-recommended web standard (via [WCAG](https://www.w3.org/TR/WCAG/)).
 
 Scientific Python communities and their projects need to be accessible and inclusive of disabled people. This SPEC is an agreement between projects to 
@@ -33,10 +26,6 @@ At the time of writing, accessibility is not a regular consideration in many Sci
 If you are interested in this effort, [join us now](accessibility.scientific-python.org/community.html)!
 
 ## Implementation
-
-<!--
-Discuss how this would be implemented.
--->
 
 ### Global accessibility guidelines
 
@@ -63,19 +52,6 @@ This may include recommendations that are in progress or have been requested by 
 
 ### Core Project Endorsement
 
-<!--
-Discuss what it means for a core project to endorse this SPEC.
--->
-
 ### Ecosystem Adoption
 
-<!--
-Discuss what it means for a project to adopt this SPEC.
--->
-
 ## Notes
-
-<!--
-Include a bulleted list of annotated links, comments,
-and other ancillary information as needed.
--->

--- a/spec-0003/index.md
+++ b/spec-0003/index.md
@@ -12,16 +12,16 @@ endorsed-by:
 
 [Accessibility](https://en.wikipedia.org/wiki/Accessibility) is building things that are fully usable for people with disabilities. [There are many reasons to prioritize accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/#important)), including ethical, user experience, and legal motivations. Accessibility is also a long-recommended web standard (via [WCAG](https://www.w3.org/TR/WCAG/)).
 
-Scientific Python communities and their projects need to be accessible and inclusive of disabled people. This SPEC is an agreement between projects to 
+Scientific Python communities and their projects need to be accessible and inclusive of disabled people. This SPEC is an agreement between projects to
 
-1. Actively make their work more accessible from software to documentation to community and more. 
+1. Actively make their work more accessible from software to documentation to community and more.
 2. Adopt global accessibility guidelines and Scientific Python-specific recommendations as is relevant per project.
 3. Investigate accessibility solutions where they find gaps in existing recommendations (especially for use cases specific to this ecosystem).
-4. Share accessibility knowledge and efforts across projects whenever possible. 
+4. Share accessibility knowledge and efforts across projects whenever possible.
 
 ## Community
 
-At the time of writing, accessibility is not a regular consideration in many Scientific Python projects. Many projects may have a handful of people who have accessibility knowledge or are interested in acquiring more, but may not be able to reach critical mass on a per-project basis. Connecting Scientific Python community members focused on accessibility will provide a boon for individuals, projects, and the ecosystem at large. 
+At the time of writing, accessibility is not a regular consideration in many Scientific Python projects. Many projects may have a handful of people who have accessibility knowledge or are interested in acquiring more, but may not be able to reach critical mass on a per-project basis. Connecting Scientific Python community members focused on accessibility will provide a boon for individuals, projects, and the ecosystem at large.
 
 If you are interested in this effort, [join us now](accessibility.scientific-python.org/community.html)!
 
@@ -40,6 +40,7 @@ Please note that in many cases guidelines serve as a foundation for accessibilit
 For cases where ecosystem-specific recommendations are needed or examples of accessibility within the ecosystem are helpful, we also provide a list of resources designed to support the needs of our community.
 
 If you would like to add, edit or suggest new recommendations, join the community at [accessibility.scientific-python.org](accessibility.scientific-python.org/community.html)
+
 #### Existing recommendations
 
 - [Image descriptions (including alt text)](https://accessibility.scientific-python.org/reference.html)


### PR DESCRIPTION
@MarsBarLee and I have been trying to sort out a way to handle the work and scope of this draft SPEC based on the knowledge and time we have to offer. This PR restructures the SPEC to include sub topics.

This version of the draft SPEC allows for the broad "accessibility" topic while also giving us room to contribute image description information specifically. We hope this is a solid compromise that leaves this project lots of room to grow if desired.

Some of the content removed in this PR will be moved to [accessibility.scientific-python.org](https://github.com/scientific-python/accessibility.scientific-python.org). If it helps, you can see progress on [our working PR for the website](https://github.com/isabela-pf/accessibility.scientific-python.org/pull/1).

References discussion on [scientific-python/accessibility.scientific-python.org #4](https://github.com/scientific-python/accessibility.scientific-python.org/issues/4).

Let me know if you have any questions or see any errors. Thanks in advance for any review! 🌻 