### PR TITLE
Add notes about CI Best Practices from 2022 NumFocus summit

### DIFF
--- a/spec-0005/index.md
+++ b/spec-0005/index.md
@@ -4,6 +4,7 @@ date: 2022-09-22
 author:
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Ryan May <rmay@ucar.edu>"
+  - "Brigitta Sipőcz <brigitta.sipocz@gmail.com>"
 discussion: https://discuss.scientific-python.org/t/spec-5-ci-best-practices/507
 endorsed-by:
 ---

--- a/spec-0005/index.md
+++ b/spec-0005/index.md
@@ -51,6 +51,7 @@ and other ancillary information as needed.
   - Could use for pins
   - Can use labels to trigger additional runs of "exotic" jobs
   - Can open an issue on failure rather than hiding in a UI somewhere--helps give notifications
+  - Generate a badge for the workflow, that can be collected into a dashboard
 
 - GitHub actions security concerns
   - Need to trust action creators

--- a/spec-0005/index.md
+++ b/spec-0005/index.md
@@ -3,6 +3,7 @@ title: "SPEC 5 — CI Best Practices"
 date: 2022-09-22
 author:
   - "Jarrod Millman <millman@berkeley.edu>"
+  - "Ryan May <rmay@ucar.edu>"
 discussion: https://discuss.scientific-python.org/t/spec-5-ci-best-practices/507
 endorsed-by:
 ---
@@ -40,3 +41,17 @@ Discuss what it means for a project to adopt this SPEC.
 Include a bulleted list of annotated links, comments,
 and other ancillary information as needed.
 -->
+
+- Recommend that CI running against PRs be expected to pass--if it fails, it should be important
+
+- Schedule regular runs of CI against nightlies/pre-releases
+
+  - Good for other checks that don't need to run on every PR
+  - Could use for pins
+  - Can use labels to trigger additional runs of "exotic" jobs
+  - Can open an issue on failure rather than hiding in a UI somewhere--helps give notifications
+
+- GitHub actions security concerns
+  - Need to trust action creators
+  - Pin to hash vs. version/tag?
+  -


### PR DESCRIPTION
Here are the notes from our discussion at the NumFocus summit.