### PR TITLE
Add TOC to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ The Scientific Python Ecosystem Coordination (SPEC) mechanism is used to recomme
 project policies, coding conventions, and standard tooling.
 
 See https://scientific-python.org/specs/
+
+
+| # | Title | Proposed | Accepted | DOI |
+| --- | --- | --- | --- | --- |
+| | [SPEC Purpose and Process](https://github.com/scientific-python/specs/blob/main/purpose-and-process/index.md) | 2020-12-17 | | | 
+| 0 | [Minimum Supported Versions](https://github.com/scientific-python/specs/blob/main/spec-0000/index.md) | 2020-12-17 | | |
+| 1 | [Lazy Loading of Submodules and Functions](https://github.com/scientific-python/specs/blob/main/spec-0001/index.md) | 2020-12-17 | | |
+| 2 | [API Dispatch](https://github.com/scientific-python/specs/blob/main/spec-0002/index.md) | 2021-12-16 | | |
+| 3 | [Accessibility](https://github.com/scientific-python/specs/blob/main/spec-0003/index.md) | 2022-02-14 | | |
+| 4 | [Nightly Wheels](https://github.com/scientific-python/specs/blob/main/spec-0004/index.md) | 2022-09-05 | | |
+| 5 | [CI Best Practices](https://github.com/scientific-python/specs/blob/main/spec-0005/index.md) | 2022-09-22 | | |


### PR DESCRIPTION
I do not want to click on each and every folder to see what the SPECs are about, so would be nice to have a TOC like https://github.com/astropy/astropy-APEs . 😅 

I am not sure if these are the columns you want, so I am happy to modify the columns. Would be nice for outsider to see the statuses of the SPECs at a glance too. And once SPEC is accepted, would be nice to have a permanent DOI people can cite.