### PR TITLE
Fix links

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -6,12 +6,11 @@ hide_meta: true
 SPECs provide operational guidelines for projects in the scientific Python ecosystem.
 All community members and ecosystem projects are welcome to participate in the SPEC process.
 The SPEC process is described in the
-[SPEC Purpose and Process]({{< relref "/specs/purpose-and-process" >}}),
-[SPEC Steering Committee]({{< relref "/specs/steering-committee" >}}), and
-[SPEC Core Projects]({{< relref "/specs/core-projects" >}}) documents.
+[SPEC Purpose and Process]({{< relref "/purpose-and-process" >}}),
+[SPEC Steering Committee]({{< relref "/steering-committee" >}}), and
+[SPEC Core Projects]({{< relref "/core-projects" >}}) documents.
 Community discussions take place on the
 [`SPECs` Discourse forum](https://discuss.scientific-python.org/c/specs/6).
+SPEC development takes place in the [SPEC repository](https://github.com/scientific-python/specs).
 
-Contributors must adhere to our [code of conduct]({{< relref "/code_of_conduct.md" >}}).
-
-SPEC development takes place at https://github.com/scientific-python/specs.
+Contributors must adhere to our [code of conduct](https://scientific-python.org/code_of_conduct/).

--- a/core-projects/_index.md
+++ b/core-projects/_index.md
@@ -16,7 +16,7 @@ or implementations of fundamental algorithms.
 Due to their central position in the ecosystem, the policies, practices, and tooling
 used by the Core Projects are widely seen by the ecosystem
 and impact many other projects.
-The [Steering Committee]({{< relref "/specs/steering-committee" >}}) maintains the list of
+The [Steering Committee]({{< relref "/steering-committee" >}}) maintains the list of
 Core Projects.
 
 Core Projects endorse SPEC documents.

--- a/purpose-and-process/_index.md
+++ b/purpose-and-process/_index.md
@@ -36,7 +36,7 @@ That said, SPECs serve their purpose through being adopted by
 several projects—and their authority stems from the extent to which they are.
 
 Participants in the SPEC process must adhere to our
-[Code of Conduct]({{< relref "/code_of_conduct.md" >}}).
+[Code of Conduct](https://scientific-python.org/code_of_conduct/).
 
 ### Key Terms
 
@@ -46,21 +46,21 @@ widely used in scientific research that interact well with one another and that
 follow similar norms of development, documentation, testing, and so forth.
 
 SPEC Core Projects
-: The [Core Projects]({{< relref "/specs/core-projects" >}})
+: The [Core Projects]({{< relref "/core-projects" >}})
 are a small subset of the ecosystem consisting of mature, community developed projects
 that are (a) depended upon by most of the other projects and (b) responsible for
 reviewing, discussing, implementing, and endorsing SPEC documents.
 
 SPEC Steering Committee
-: The [Steering Committee]({{< relref "/specs/steering-committee" >}}) leads the SPEC project and
+: The [Steering Committee]({{< relref "/steering-committee" >}}) leads the SPEC project and
 manages the SPEC process including moderating
 the [SPECs discussion forum](https://discuss.scientific-python.org/c/specs/6),
 accepting SPEC documents, and maintaining the SPEC process documents.
 
 SPEC Process
 : The SPEC process is outlined in this document and the associated
-[SPEC Steering Committee]({{< relref "/specs/steering-committee" >}}) and
-[SPEC Core Projects]({{< relref "/specs/core-projects" >}}) documents.
+[SPEC Steering Committee]({{< relref "/steering-committee" >}}) and
+[SPEC Core Projects]({{< relref "/core-projects" >}}) documents.
 This process is managed and overseen by the Steering Committee, and functions in collaboration
 with the Core Projects, community members, and projects across the ecosystem.
 
@@ -122,7 +122,7 @@ common concern and a general approach to a shared solution and (b) there
 are contributors (from at least two Core Projects) interested in working on the new SPEC
 and in championing it to their projects as well as the larger community.
 Additional details may be found in
-[Steering Committee documentation]({{< relref "/specs/steering-committee" >}}).
+[Steering Committee documentation]({{< relref "/steering-committee" >}}).
 
 The **endorse decision** is made by the Core Projects.
 The Core Projects and interested community members revise the accepted SPEC in a
@@ -134,7 +134,7 @@ A SPEC is recommended for wide-spread adoption once it is endorsed by two (or mo
 Once a SPEC is recommended, further changes require the approval of all endorsing
 Core Projects.
 Additional details may be found in
-[Core Project documentation]({{< relref "/specs/core-projects" >}}).
+[Core Project documentation]({{< relref "/core-projects" >}}).
 
 The **adopt decision** is made by individual projects according to their own decision-making
 processes.

--- a/steering-committee/_index.md
+++ b/steering-committee/_index.md
@@ -11,18 +11,18 @@ author:
 The SPEC process is managed by the Steering Committee.
 The Steering Committee represents the interests of the ecosystem and the community.
 The Steering Committee also represent the interests of the
-[Core Projects]({{< relref "/specs/core-projects" >}})
+[Core Projects]({{< relref "/core-projects" >}})
 and is composed partially of individuals who are active Core Project contributors.
 In particular, the Steering Committee members
 
 - monitor the
   [SPECs discussion forum](https://discuss.scientific-python.org/c/specs/6),
 - determine which proposed SPECs are accepted as described in the [SPEC
-  Purpose and Process]({{< relref "/specs/purpose-and-process" >}}),
+  Purpose and Process]({{< relref "/purpose-and-process" >}}),
 - approve changes to the SPEC process including to the
-  [SPEC Purpose and Process]({{< relref "/specs/purpose-and-process" >}}),
-  [SPEC Steering Committee]({{< relref "/specs/steering-committee" >}}), and
-  [SPEC Core Projects]({{< relref "/specs/core-projects" >}}), as well as
+  [SPEC Purpose and Process]({{< relref "/purpose-and-process" >}}),
+  [SPEC Steering Committee]({{< relref "/steering-committee" >}}), and
+  [SPEC Core Projects]({{< relref "/core-projects" >}}), as well as
 - serve as a communication channel to and from projects they contribute to as
   well as the larger ecosystem.
 
@@ -51,9 +51,9 @@ appropriate,[^accept] objections should be rare.
 ### How is the SPEC process changed?
 
 The Steering Committee makes decisions about changing the SPEC process documents
-([SPEC Purpose and Process]({{< relref "/specs/purpose-and-process" >}}),
-[SPEC Steering Committee]({{< relref "/specs/steering-committee" >}}), and
-[SPEC Core Projects]({{< relref "/specs/core-projects" >}}))
+([SPEC Purpose and Process]({{< relref "/purpose-and-process" >}}),
+[SPEC Steering Committee]({{< relref "/steering-committee" >}}), and
+[SPEC Core Projects]({{< relref "/core-projects" >}}))
 through group consensus and, in the very rare instance
 where no consensus can be reached, by two-thirds majority vote of those
 available to cast a vote within ten days.


### PR DESCRIPTION
This is in preparation for https://github.com/scientific-python-specs/specs.scientific-python.org/pull/3, but doesn't break the old site.