### PR TITLE
Minor updates to the current spec text.

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -38,10 +38,10 @@ We recommend that projects add a cron job to test against the nightly wheels and
 when errors are encountered to automatically open an issue in their project so they
 can investigate.
 
-The nightly wheels for conda can be found [here](https://anaconda.org/scientific-python-nightly-wheels/).
+The nightly wheels can be found [here](https://anaconda.org/scientific-python-nightly-wheels/).
 
 We have a GitHub action to upload new nightly wheels and remove old ones:
-https://github.com/scientific-python/nightly-wheels
+https://github.com/scientific-python/upload-nightly-action
 
 ### Core Project Endorsement
 


### PR DESCRIPTION
We have been discussing that the usage of nightly wheels is part of the CI best practices, and spec5, and this spec4 could be rephrased about building and distributing nightly wheels for projects with significant downstream library usage.

Nevertheless, this PR is a trivial wordsmithing that fixes the actual action we use for the wheels, etc.