### PR TITLE
Change SPEC4 to cover using and building nightly wheels

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -88,6 +88,26 @@ workflow" add the following lines as an additional step:
 Complete examples of how projects implement this in their CI setup are linked in the Notes section.
 
 
+#### Process for Adding New Projects
+
+After someone emails nightly-wheels@scientific-python.org requesting access to upload wheels
+a human has to respond to that request.
+
+We want to be open to projects uploading wheels but at the same time need to perform some
+amount of due dilligence before giving people access. This is because once a user is given
+access they could upload wheels for any project. We assume that people are not malicious
+and we can see from the logs who misbehaved after the fact.
+
+Once you have established who the person is that contacted nightly-wheels@scientific-python.org
+and that they represent the project they say they are representing reply to the email.
+Ask the person to create an account on https://anaconda.org and tell you the username.
+You can then add them to the `scientific-python-nightly-wheels` organisation on anaconda.org.
+Let the user know that they have been added and that they can create a access token at
+https://anaconda.org/scientific-python-nightly-wheels/settings/access. The token should
+only have the "Allow uploads to Standard Python repositories" scope and use the project
+name as the token name.
+
+
 ## Core Project Endorsement
 
 <!--

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -1,10 +1,11 @@
 ---
-title: "SPEC 4 — Nightly Wheels"
+title: "SPEC 4 — Using and Creating Nightly Wheels"
 date: 2022-09-05
 author:
-  - "Jarrod Millman <millman@berkeley.edu>"
   - "Matthew Feickert <matthew.feickert@cern.ch>"
   - "Olivier Grisel <olivier.grisel@ensta.org>"
+  - "Tim Head <betatim@gmail.com>"
+  - "Jarrod Millman <millman@berkeley.edu>"
 discussion: https://discuss.scientific-python.org/t/spec-4-nightly-wheels/474
 endorsed-by:
 ---
@@ -18,38 +19,82 @@ If relevant, include examples of how the new functionality would be used,
 intended use-cases, and pseudo-code illustrating its use.
 -->
 
-This SPEC recommends that projects test against nightly wheels of several
-widely-used projects in the Scientific Python ecosystem.
+This SPEC describes how to test against nightly wheels of several widely used
+projects and how to create nightly wheels for your project.
 
-There are two main motivations for this recommendation:
+Regularly running your project's tests while using the nightly version of your
+dependencies allows you to spot problems caused by changes before a new release
+is made. This way potential issues can be resolved before they find their way
+into a release, at which point it becomes much harder to change or revert
+something.
 
-1. Testing against nightly wheels will help identify when changes to the main branch
-   of the widely-used projects break downstream projects.
-2. By using the nightly wheels projects will not have to build packages from source,
-   which can be difficult and time consumming.
+Regularly creating nightly wheels for your project allows projects that depend on
+you to give feedback about upcoming changes. As with testing against nightlies of
+your dependencies this gives your dependents a chance to report problems before they
+find their way into a release.
+
 
 ## Implementation
 
-<!--
-Discuss how this would be implemented.
--->
+This section outlines how to implement using and building nightly wheels. We assume your
+project already has some amount of CI infrastructure and that you will have to fit this
+in with the existing setup. In the notes section we link to projects who have implemented
+this in their setup to give you examples of complete setups.
 
-We recommend that projects add a cron job to test against the nightly wheels and
-when errors are encountered to automatically open an issue in their project so they
-can investigate.
+### Test with Nightly Wheels
 
-The nightly wheels can be found [here](https://anaconda.org/scientific-python-nightly-wheels/).
+We recommend that projects add a weekly cron job to run their tests using nightly versions
+of their dependencies. The cron job should automatically open an issue on your repository
+when it encounters an error.
 
-We have a GitHub action to upload new nightly wheels and remove old ones:
-https://github.com/scientific-python/upload-nightly-action
+If you spot a problem please investigate if this is due to a known deprecation or
+bug fix. If you think it is neither, please report it to the relevant upstream project.
 
-### Core Project Endorsement
+To install the nightly version of your dependencies check which of them are available
+at https://anaconda.org/scientific-python-nightly-wheels/. For example to install the NumPy, pandas and scipy nightlies use:
+
+```
+pip install --pre --upgrade --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy pandas scipy
+```
+
+Complete examples of how projects implement this in their CI setup are linked in the Notes section.
+
+### Build Nightly Wheels
+
+There are a few steps to implementing this for your project:
+
+1. Get access to https://anaconda.org/scientific-python-nightly-wheels/, the location used to host nightly wheels
+2. Setup a CI step that builds wheels for your project
+3. Setup a CI step that uploads wheels to https://anaconda.org/scientific-python-nightly-wheels/
+
+For step (1) contact nightly-wheels@scientific-python.org. Deposit the token you get as a [secret on your repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets) named `UPLOAD_TOKEN`.
+
+The work for step (2) depends on your project. You are probably already doing this for your
+releases. The new thing to add is that building wheels is run on a schedule every night or
+once a week.
+
+For step (3) there is a GitHub Action that you can use. You can find the action at
+https://github.com/scientific-python/upload-nightly-action. To use it in your "build wheels
+workflow" add the following lines as an additional step:
+
+```
+- name: Upload wheel
+  uses: scientific-python/upload-nightly-action@main
+  with:
+    artifacts_path: dist/
+    anaconda_nightly_upload_token: ${{ secrets.UPLOAD_TOKEN }}
+```
+
+Complete examples of how projects implement this in their CI setup are linked in the Notes section.
+
+
+## Core Project Endorsement
 
 <!--
 Discuss what it means for a core project to endorse this SPEC.
 -->
 
-### Ecosystem Adoption
+## Ecosystem Adoption
 
 <!--
 Discuss what it means for a project to adopt this SPEC.
@@ -61,3 +106,7 @@ Discuss what it means for a project to adopt this SPEC.
 Include a bulleted list of annotated links, comments,
 and other ancillary information as needed.
 -->
+
+* You can use [scikit-learn's GitHub Action wheels building workflow](https://github.com/scikit-learn/scikit-learn/blob/f034f57b1ad7bc5a7a5dd342543cea30c85e74ff/.github/workflows/wheels.yml)
+as an example of how to build wheels and upload them to the nightly area.
+* An example of [a GitHub Action workflow that creates a tracking issue for failed CI runs](https://github.com/scikit-learn/scikit-learn/blob/689efe2f25356aa674bd0090f44b0914aae4d3a3/.github/workflows/update_tracking_issue.yml)

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -50,10 +50,10 @@ If you spot a problem please investigate if this is due to a known deprecation o
 bug fix. If you think it is neither, please report it to the relevant upstream project.
 
 To install the nightly version of your dependencies check which of them are available
-at https://anaconda.org/scientific-python-nightly-wheels/. For example to install the NumPy, pandas and scipy nightlies use:
+at https://anaconda.org/scientific-python-nightly-wheels/. For example to install the NumPy and scipy nightlies use:
 
 ```
-pip install --pre --upgrade --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy pandas scipy
+pip install --pre --upgrade --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
 ```
 
 Complete examples of how projects implement this in their CI setup are linked in the Notes section.
@@ -66,7 +66,9 @@ There are a few steps to implementing this for your project:
 2. Setup a CI step that builds wheels for your project
 3. Setup a CI step that uploads wheels to https://anaconda.org/scientific-python-nightly-wheels/
 
-For step (1) contact nightly-wheels@scientific-python.org. Deposit the token you get as a [secret on your repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets) named `UPLOAD_TOKEN`.
+For step (1) visit https://github.com/scientific-python/upload-nightly-action and create an issue
+requesting access. List the project you maintain and would like to upload nightlies for. Someone
+will reply to the issue and let you know what happens next.
 
 The work for step (2) depends on your project. You are probably already doing this for your
 releases. The new thing to add is that building wheels is run on a schedule every night or
@@ -88,22 +90,27 @@ Complete examples of how projects implement this in their CI setup are linked in
 
 #### Process for Adding New Projects
 
-After someone emails nightly-wheels@scientific-python.org requesting access to upload wheels
-a human has to respond to that request.
+After someone creates an issue on https://github.com/scientific-python/upload-nightly-action
+requesting access to upload wheels a human has to respond to that request.
 
 We want to be open to projects uploading wheels but at the same time need to perform some
 amount of due dilligence before giving people access. This is because once a user is given
 access they could upload wheels for any project. We assume that people are not malicious
 and we can see from the logs who misbehaved after the fact.
 
-Once you have established who the person is that contacted nightly-wheels@scientific-python.org
-and that they represent the project they say they are representing reply to the email.
-Ask the person to create an account on https://anaconda.org and tell you the username.
+Once you have established who the person is and that they represent the project they want
+to upload wheels for ask the person to create an account on https://anaconda.org and tell
+you the username.
+
 You can then add them to the `scientific-python-nightly-wheels` organisation on anaconda.org.
 Let the user know that they have been added and that they can create a access token at
 https://anaconda.org/scientific-python-nightly-wheels/settings/access. The token should
-only have the "Allow uploads to Standard Python repositories" scope and use the project
-name as the token name.
+only have the "Allow uploads to Standard Python repositories" and
+"Allow write access to the API site" scope. It should use the project name as the token name.
+
+You can also add new people to https://anaconda.org/scientific-python-nightly-wheels when they
+contact you privately, but it would be good if an issue is created as part of that. This helps
+with keeping track of who did what when.
 
 ## Core Project Endorsement
 
@@ -126,4 +133,5 @@ and other ancillary information as needed.
 
 - You can use [scikit-learn's GitHub Action wheels building workflow](https://github.com/scikit-learn/scikit-learn/blob/f034f57b1ad7bc5a7a5dd342543cea30c85e74ff/.github/workflows/wheels.yml)
   as an example of how to build wheels and upload them to the nightly area.
+- [numpy's GitHub Action workflow for building wheels and uploading them](https://github.com/numpy/numpy/blob/cc0abd768575d7f9e862de0b4912af27f6e9690d/.github/workflows/wheels.yml)
 - An example of [a GitHub Action workflow that creates a tracking issue for failed CI runs](https://github.com/scikit-learn/scikit-learn/blob/689efe2f25356aa674bd0090f44b0914aae4d3a3/.github/workflows/update_tracking_issue.yml)

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -33,7 +33,6 @@ you to give feedback about upcoming changes. As with testing against nightlies o
 your dependencies this gives your dependents a chance to report problems before they
 find their way into a release.
 
-
 ## Implementation
 
 This section outlines how to implement using and building nightly wheels. We assume your
@@ -87,7 +86,6 @@ workflow" add the following lines as an additional step:
 
 Complete examples of how projects implement this in their CI setup are linked in the Notes section.
 
-
 #### Process for Adding New Projects
 
 After someone emails nightly-wheels@scientific-python.org requesting access to upload wheels
@@ -106,7 +104,6 @@ Let the user know that they have been added and that they can create a access to
 https://anaconda.org/scientific-python-nightly-wheels/settings/access. The token should
 only have the "Allow uploads to Standard Python repositories" scope and use the project
 name as the token name.
-
 
 ## Core Project Endorsement
 
@@ -127,6 +124,6 @@ Include a bulleted list of annotated links, comments,
 and other ancillary information as needed.
 -->
 
-* You can use [scikit-learn's GitHub Action wheels building workflow](https://github.com/scikit-learn/scikit-learn/blob/f034f57b1ad7bc5a7a5dd342543cea30c85e74ff/.github/workflows/wheels.yml)
-as an example of how to build wheels and upload them to the nightly area.
-* An example of [a GitHub Action workflow that creates a tracking issue for failed CI runs](https://github.com/scikit-learn/scikit-learn/blob/689efe2f25356aa674bd0090f44b0914aae4d3a3/.github/workflows/update_tracking_issue.yml)
+- You can use [scikit-learn's GitHub Action wheels building workflow](https://github.com/scikit-learn/scikit-learn/blob/f034f57b1ad7bc5a7a5dd342543cea30c85e74ff/.github/workflows/wheels.yml)
+  as an example of how to build wheels and upload them to the nightly area.
+- An example of [a GitHub Action workflow that creates a tracking issue for failed CI runs](https://github.com/scikit-learn/scikit-learn/blob/689efe2f25356aa674bd0090f44b0914aae4d3a3/.github/workflows/update_tracking_issue.yml)

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -23,7 +23,7 @@ This SPEC describes how to test against nightly wheels of several widely used
 projects and how to create nightly wheels for your project.
 
 Regularly running your project's tests while using the nightly version of your
-dependencies allows you to spot problems caused by changes before a new release
+dependencies allows you to spot problems caused by upstream changes before a new release
 is made. This way potential issues can be resolved before they find their way
 into a release, at which point it becomes much harder to change or revert
 something.


### PR DESCRIPTION
🚧 This is work in progress.

The goal is to create a SPEC that covers both using and creating nightlies.

I am trying to keep it kind of high-level, giving examples of how to do the things that are new (e.g. uploading to the nightly area) but not be too prescriptive/show full blown CI setups because I assume the target audience are likely to already have fairly sophisticated/complex/complicated CI setups. For example scikit-learn uses Azure to run their unit tests, but uses GH Actions to build wheels. I think this is good, we don't want people to revamp their whole CI setup.

* [ ] link to more examples of how projects have implemented this (numpy, scipy, pandas, ...)
* [x] add more sentences that explain why people should do this?
* [ ] point out that if you publish nightlies people will give you feedback (and you'll need capacity to deal with that)?

Closes #188 