### PR TITLE
Add NEP 29 authors to spec0

### DIFF
--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -2,6 +2,7 @@
 title: "SPEC 0 — Minimum Supported Versions"
 date: 2020-12-17
 author:
+  - "Brigitta Sipőcz <brigitta.sipocz@gmail.com>"
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Madicken Munk <madicken@berkeley.edu>"
   - "Matt Haberland <mhaberla@calpoly.edu>"

--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -3,6 +3,9 @@ title: "SPEC 0 — Minimum Supported Versions"
 date: 2020-12-17
 author:
   - "Jarrod Millman <millman@berkeley.edu>"
+  - "Madicken Munk <madicken@berkeley.edu>"
+  - "Matt Haberland <mhaberla@calpoly.edu>"
+  - "Matthias Bussonnier <bussonniermatthias@gmail.com>"
   - "Ross Barnowski <rossbar@berkeley.edu>"
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
 discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-versions/33

--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -8,6 +8,7 @@ author:
   - "Matt Haberland <mhaberla@calpoly.edu>"
   - "Matthias Bussonnier <bussonniermatthias@gmail.com>"
   - "Thomas A Caswell <tcaswell@gmail.com>"
+  - "Ralf Gommers <ralf.gommers@gmail.com>"
   - "Ross Barnowski <rossbar@berkeley.edu>"
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
 discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-versions/33

--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -2,15 +2,16 @@
 title: "SPEC 0 — Minimum Supported Versions"
 date: 2020-12-17
 author:
+  - "Andreas C. Mueller <andreas.mueller.ml@gmail.com>"
   - "Brigitta Sipőcz <brigitta.sipocz@gmail.com>"
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Madicken Munk <madicken@berkeley.edu>"
   - "Matt Haberland <mhaberla@calpoly.edu>"
   - "Matthias Bussonnier <bussonniermatthias@gmail.com>"
-  - "Thomas A Caswell <tcaswell@gmail.com>"
   - "Ralf Gommers <ralf.gommers@gmail.com>"
   - "Ross Barnowski <rossbar@berkeley.edu>"
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
+  - "Thomas A Caswell <tcaswell@gmail.com>"
 discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-versions/33
 endorsed-by:
   - ipython

--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -7,6 +7,7 @@ author:
   - "Madicken Munk <madicken@berkeley.edu>"
   - "Matt Haberland <mhaberla@calpoly.edu>"
   - "Matthias Bussonnier <bussonniermatthias@gmail.com>"
+  - "Thomas A Caswell <tcaswell@gmail.com>"
   - "Ross Barnowski <rossbar@berkeley.edu>"
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
 discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-versions/33


### PR DESCRIPTION
This PR adds authors who originally contributed to NEP 29 to spec0. The authors I already added I have verbal consent from or have already contributed to NEP 0 at the developer summit. 

@tacaswell @rgommers @amueller and @ellisonbg would you like to be added as authors to this SPEC as well? 
