### PR TITLE
Spec 0004 community wording suggestions

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -101,9 +101,9 @@ The admins are drawn from active members from the scientific Python community.
 Ideally, the collection of admins comprises a broad selection of community
 members across different projects and underlying organizations.
 This is to ensure community ownership of the wheel-hosting infrastructure and
-ensure that adminstration is governed by consensus, as opposed to unilateral
+adminstration governed by consensus, as opposed to unilateral
 decision-making by any individual, project, or organization.
-Adding new people to the list of admins requires at least an issue to be opened.
+Adding new administrators requires at least an issue to be opened.
 After someone creates an issue on https://github.com/scientific-python/upload-nightly-action
 requesting access to upload wheels a human/admin has to respond to that request.
 
@@ -112,13 +112,10 @@ amount of due dilligence before giving people access. This is because once a use
 access their work will be broadcasted through the broad exposure of Scientific Python. This
 could be abused to publish malicious packages.
 
-Once a project has chosen the person or persons who they wish to serve as
-adminstrators for the nightly wheels, those person(s) should create an
-account on https://anaconda.org and share the resulting usernames with the
+A project's chosen administrators should each create an
+account on https://anaconda.org and share their usernames with the
 project.
-We suggest that each project have at least 2 representatives for redundancy and to
-ensure that the pool of administrators is sufficiently broad and representative
-of the underlying community.
+To increase resilience, we suggest that each project have at least two administrators.
 
 You (as an admin) can then generate a personal access token at
 https://anaconda.org/[user]/settings/access.

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -97,28 +97,30 @@ Complete examples of how projects implement this in their CI setup are linked in
 
 #### Process for Adding New Projects
 
-The admins are drawn from active members from the scientific Python community.
+The site admins are drawn from active members from the scientific Python community.
 Ideally, the collection of admins comprises a broad selection of community
 members across different projects and underlying organizations.
 This is to ensure community ownership of the wheel-hosting infrastructure and
 adminstration governed by consensus, as opposed to unilateral
 decision-making by any individual, project, or organization.
 Adding new administrators requires at least an issue to be opened.
-After someone creates an issue on https://github.com/scientific-python/upload-nightly-action
-requesting access to upload wheels a human/admin has to respond to that request.
+After a project creates an issue on https://github.com/scientific-python/upload-nightly-action
+requesting access to upload wheels a admin has to respond to that request.
 
 We want to be open to projects uploading wheels but at the same time need to perform some
-amount of due dilligence before giving people access. This is because once a user is given
+amount of due dilligence before giving people access. This is because once a project is given
 access their work will be broadcasted through the broad exposure of Scientific Python. This
 could be abused to publish malicious packages.
 
-A project's chosen administrators should each create an
+A project's chosen representative should each create an
 account on https://anaconda.org and share their usernames with the
 project.
-To increase resilience, we suggest that each project have at least two administrators.
+To increase resilience, we suggest that each project have at least two registered
+representatives.
 
-You (as an admin) can then generate a personal access token at
-https://anaconda.org/[user]/settings/access.
+The representative can then generate a personal access token at
+https://anaconda.org/[user]/settings/access and use it in CI to upload
+wheels.
 The token should only have the "Allow uploads to Standard Python repositories",
 "Allow read access to the API site" and "Allow write access to the API site" scope.
 The creation of tokens at the organization level should be avoided for security reasons.

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -114,7 +114,7 @@ could be abused to publish malicious packages.
 
 A project's chosen representatives should each create an
 account on https://anaconda.org and share their usernames with the
-project.
+admins of the Scientific Python organization on Anaconda.
 To increase resilience, we suggest that each project have at least two registered
 representatives.
 

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -97,9 +97,6 @@ Complete examples of how projects implement this in their CI setup are linked in
 
 #### Process for Adding New Projects
 
-After someone creates an issue on https://github.com/scientific-python/upload-nightly-action
-requesting access to upload wheels a human/admin has to respond to that request.
-
 The admins are drawn from active members from the scientific Python community.
 Ideally, the collection of admins comprises a broad selection of community
 members across different projects and underlying organizations.
@@ -107,6 +104,8 @@ This is to ensure community ownership of the wheel-hosting infrastructure and
 ensure that adminstration is governed by consensus, as opposed to unilateral
 decision-making by any individual, project, or organization.
 Adding new people to the list of admins requires at least an issue to be opened.
+After someone creates an issue on https://github.com/scientific-python/upload-nightly-action
+requesting access to upload wheels a human/admin has to respond to that request.
 
 We want to be open to projects uploading wheels but at the same time need to perform some
 amount of due dilligence before giving people access. This is because once a user is given

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -120,9 +120,6 @@ project.
 We suggest that each project have at least 2 representatives for redundancy and to
 ensure that the pool of administrators is sufficiently broad and representative
 of the underlying community.
-When considering representatives, we suggest that projects nominate individuals
-that do not have significant community, organizational, or employer overlap
-with existing representatives to ensure that we have a diverse community.
 
 You (as an admin) can then generate a personal access token at
 https://anaconda.org/[user]/settings/access.

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -100,19 +100,26 @@ Complete examples of how projects implement this in their CI setup are linked in
 After someone creates an issue on https://github.com/scientific-python/upload-nightly-action
 requesting access to upload wheels a human/admin has to respond to that request.
 
-Admins are people from the community who are ideally not part of the same organizations nor
-project. This is to prevent malicious activities from a given group of actors and ensure a
-diverse and healthy community. Adding new people to the list of admins requires at
-least an issue to be openned.
+The admins are drawn from active members from the scientific Python community.
+Ideally, the collection of admins comprises a broad selection of community
+members across different projects and underlying organizations.
+This is to ensure community ownership of the wheel-hosting infrastructure and
+ensure that adminstration is governed by consensus, as opposed to unilateral
+decision-making by any individual, project, or organization.
+Adding new people to the list of admins requires at least an issue to be opened.
 
 We want to be open to projects uploading wheels but at the same time need to perform some
 amount of due dilligence before giving people access. This is because once a user is given
 access their work will be broadcasted through the broad exposure of Scientific Python. This
 could be abused to publish malicious packages.
 
-Once you have established who the person is and that they represent the project they want
-to upload wheels for ask the person to create an account on https://anaconda.org and tell
-you the username. We suggest that projects have at least 2 representatives.
+Once a project has chosen the person or persons who they wish to serve as
+adminstrators for the nightly wheels, those person(s) should create an
+account on https://anaconda.org and share the resulting usernames with the
+project.
+We suggest that each project have at least 2 representatives for redundancy and to
+ensure that the pool of administrators is sufficiently broad and representative
+of the underlying community.
 When considering representatives, we suggest that projects nominate individuals
 that do not have significant community, organizational, or employer overlap
 with existing representatives to ensure that we have a diverse community.

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -112,7 +112,7 @@ amount of due dilligence before giving people access. This is because once a pro
 access their work will be broadcasted through the broad exposure of Scientific Python. This
 could be abused to publish malicious packages.
 
-A project's chosen representative should each create an
+A project's chosen representatives should each create an
 account on https://anaconda.org and share their usernames with the
 project.
 To increase resilience, we suggest that each project have at least two registered


### PR DESCRIPTION
A couple minor wording suggestions based on discussions from the NumPy triage meeting on June 14th, 2023.

The goal of the proposed rewording is to help clarify the underlying motivation for the admin selection process, and to clarify the distinction between the adminstrators' decision-making  from that of the individual projects nominating representatives.

I also proposed to remove a sentence in d0341ca which had caused some confusion. In practice, this would require each project to know the complete set of existing administrators and their affiliations which seems overly burdensome (especially as the number of projects grows). My interpretation of the original intent was to make clear that the pool of administrators should be representative of the whole community, and to ensure that any one organization is not over-represented. My hope is that the proposed rewording emphasizes this point but in a slightly less prescriptive manner.