### PR TITLE
NumPy project endorses SPEC 0

### DIFF
--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -16,6 +16,7 @@ discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-ver
 endorsed-by:
   - ipython
   - networkx
+  - numpy
   - scikit-image
 ---
 


### PR DESCRIPTION
After some discussion, the NumPy Steering Council has made a decision to endorse SPEC 0.