### PR TITLE
Remove link to defunct website

### DIFF
--- a/spec-0002/index.md
+++ b/spec-0002/index.md
@@ -43,7 +43,6 @@ links to implementations related technical discussions.
 Discuss how this would be implemented.
 -->
 
-A full description of the implementation is being written up at https://github.com/scientific-python/api-dispatch. You can also view a [rendered version of that documentation](https://api-dispatch.scientific-python.org).
 
 ### Core Project Endorsement
 


### PR DESCRIPTION
This was decided in a SPEC conference call.
See #229.

This is the fist step and more needs to be done.