### PR TITLE
SciPy endorsement for SPEC-0

### DIFF
--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -18,6 +18,7 @@ endorsed-by:
   - networkx
   - numpy
   - scikit-image
+  - scipy
 ---
 
 ## Description


### PR DESCRIPTION
The discussion on SciPy's mailing list was opened here: https://mail.python.org/archives/list/scipy-dev@python.org/thread/46PKNGHVQKOKDECMIML7PZCHLKJUKBTA/

Lazy consensus applying, that means we are endorsing. I will send another email to SciPy's list with a week's additional RFC.