### PR TITLE
SPEC-4 endorsement for SciPy

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -14,6 +14,7 @@ discussion: https://discuss.scientific-python.org/t/spec-4-nightly-wheels/474
 endorsed-by:
   - networkx
   - scikit-image
+  - scipy
 ---
 
 ## Description


### PR DESCRIPTION
The discussion on SciPy's mailing list was opened here: https://mail.python.org/archives/list/scipy-dev@python.org/thread/46PKNGHVQKOKDECMIML7PZCHLKJUKBTA/

Lazy consensus applying, that means we are endorsing. I will send another email to SciPy's list with a week's additional RFC.