### PR TITLE
WIP: Create PR on main website when SPEC repo is updated

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,34 @@
+name: Update main website
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SPEC_UPDATE }}
+          repository: scientific-python/scientific-python.org
+
+      - name: Update SPECs submodule
+        run: |
+          git submodule update --init
+          cd content/specs
+          git pull origin main
+          git lg
+          cd ../..
+          git status
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.SPEC_UPDATE }}
+          delete-branch: true
+
+      -


### PR DESCRIPTION
See https://github.com/scientific-python/scientific-python.org/issues/408

The purpose of this PR is to autogenerate PRs for https://github.com/scientific-python/scientific-python.org to update the SPEC submodule when changes appear on main. I am trying to follow the instructions found here:
- https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#creating-pull-requests-in-a-remote-repository

It says you need a "a repo scoped [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) ," but I am using a "Fine-grained personal access tokens" with " Read and Write access to pull requests" to "scientific-python/scientific-python.org". 

I haven't used `peter-evans/create-pull-request` before and would love detailed feedback or suggestions on this.