### PR TITLE
Add Zarr-Python as a SPEC core project

### DIFF
--- a/core-projects/zarr.md
+++ b/core-projects/zarr.md
@@ -1,0 +1,11 @@
+---
+title: "Zarr-Python"
+avatar: https://raw.githubusercontent.com/zarr-developers/zarr-logo/main/zarr-pink-stacked.svg
+homepage: https://zarr.dev
+repository: https://github.com/zarr-developers/zarr-python
+pypi: https://pypi.org/project/zarr
+libraries-io: https://libraries.io/pypi/zarr
+license: https://github.com/zarr-developers/zarr-python/blob/main/LICENSE.txt
+license-type: MIT
+contact: msankeys963
+---


### PR DESCRIPTION
xref: #241.

Hi everyone. 👋🏻 

I've added [Zarr-Python](https://github.com/zarr-developers/zarr-python/) as one of the core projects for SPEC. Please review. Thanks!

CC: @jarrodmillman @stefanv @joshmoore @jakirkham
