### PR TITLE
NumPy project endorses SPEC 4

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -13,6 +13,7 @@ author:
 discussion: https://discuss.scientific-python.org/t/spec-4-nightly-wheels/474
 endorsed-by:
   - networkx
+  - numpy
   - scikit-image
   - scipy
 ---


### PR DESCRIPTION
After the extensive review and discussion, the NumPy Steering Council came to the consensus on endorsing SPEC 4.