### PR TITLE
Make the dependencies part explicit

### DIFF
--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -29,8 +29,8 @@ All versions refer to feature releases (i.e., Python 3.8.0, NumPy 1.19.0; not Py
 
 Specifically, we recommend that:
 
-1. Support for a given version of Python be dropped **3 years** after its initial release.
-2. Support for a given version of other core packages be dropped **2 years** after their initial release.
+1. Support for Python versions be dropped **3 years** after its initial release.
+2. Support for core package dependencies be dropped **2 years** after their initial release.
 
 ### Core Project Endorsement
 

--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -29,7 +29,7 @@ All versions refer to feature releases (i.e., Python 3.8.0, NumPy 1.19.0; not Py
 
 Specifically, we recommend that:
 
-1. Support for Python versions be dropped **3 years** after its initial release.
+1. Support for Python versions be dropped **3 years** after their initial release.
 2. Support for core package dependencies be dropped **2 years** after their initial release.
 
 ### Core Project Endorsement


### PR DESCRIPTION
Clarify that the recommendation is about "how long new releases of a package should permit older versions of dependencies", not the more conventional meaning of support as "we fix bugs for old versions" — like most medium-sized open-source projects, we (xarray) only release fixes for the current version of xarray

ref https://github.com/pydata/xarray/discussions/8237#discussioncomment-7126175

@andersy005 @shoyer @dcherian (added by @jarrodmillman )