### PR TITLE
Sort alphabetically

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -12,11 +12,11 @@ author:
 
 discussion: https://discuss.scientific-python.org/t/spec-4-nightly-wheels/474
 endorsed-by:
+  - ipython
   - networkx
   - numpy
   - scikit-image
   - scipy
-  - IPython
   - xarray
 ---
 


### PR DESCRIPTION
To make it consistent with the order in the other specs.