### PR TITLE
SPEC-4 endorsement for scikit-learn

### DIFF
--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -18,6 +18,7 @@ endorsed-by:
   - scikit-image
   - scipy
   - xarray
+  - scikit-learn
 ---
 
 ## Description


### PR DESCRIPTION
scikit-learn has adopted SPEC 4 but has not yet endorsed it.

This is currently being discussed on the scikit-learn's internal mailing list, and I would wait for several maintainers' approval and no veto before merging this PR.