### PR TITLE
Add Lars and Pamphile as SPEC-6 co-authors

### DIFF
--- a/spec-0006/index.md
+++ b/spec-0006/index.md
@@ -4,7 +4,9 @@ date: 2022-12-19
 author:
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
   - "Jarrod Millman <millman@berkeley.edu>"
-discussion:
+  - "Pamphile Roy <roy.pamphile@gmail.com>"
+  - "Lars Grüter <lagru@mailbox.org>"
+discussion: https://discuss.scientific-python.org/t/spec-6-keys-to-the-castle
 endorsed-by:
 ---
 


### PR DESCRIPTION
I forgot to update the authors list for SPEC6. Lars and Pamphile gave significant input.

@lagru @tupui let me know if this is OK?