### PR TITLE
Add Matplotlib endorsements

### DIFF
--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -16,6 +16,7 @@ author:
 discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-versions/33
 endorsed-by:
   - ipython
+  - matplotlib
   - networkx
   - numpy
   - scikit-image

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -14,6 +14,7 @@ author:
 discussion: https://discuss.scientific-python.org/t/spec-4-nightly-wheels/474
 endorsed-by:
   - ipython
+  - matplotlib
   - networkx
   - numpy
   - scikit-image


### PR DESCRIPTION
We endorse SPEC 0 (minimum dependency versions) and SPEC 4 (nightly wheels), at the least.

These are things we've already implemented, so I hope I don't need to provide any extra confirmation.