### PR TITLE
ENH: add is-draft to the SPEC template and to the listed, but still WIP specs

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -28,6 +28,7 @@ date: {now.strftime("%Y-%m-%d")}
 author:
   - "{author} <{email}>"
 discussion: https://discuss.scientific-python.org/t/
+is-draft: true
 endorsed-by:
 ---
 

--- a/spec-0002/index.md
+++ b/spec-0002/index.md
@@ -5,6 +5,7 @@ date: 2021-12-16
 author:
   - "Jarrod Millman <millman@berkeley.edu>"
 discussion:
+is-draft: true
 endorsed-by:
 ---
 

--- a/spec-0003/index.md
+++ b/spec-0003/index.md
@@ -6,6 +6,7 @@ author:
   - "Juanita Gomez <juanitagomezr2112@gmail.com>"
   - "Sarah Kaiser <sckaiser@sckaiser.com>"
 discussion: https://discuss.scientific-python.org/t/spec-3-accessibility/63
+is-draft: true
 endorsed-by:
 ---
 

--- a/spec-0005/index.md
+++ b/spec-0005/index.md
@@ -9,6 +9,7 @@ author:
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Brigitta Sipőcz <brigitta.sipocz@gmail.com>"
 discussion: https://discuss.scientific-python.org/t/spec-5-ci-best-practices/507
+is-draft: true
 endorsed-by:
 ---
 


### PR DESCRIPTION
This goes along with https://github.com/scientific-python/scientific-python.org/pull/668

I left SPEC6 and SPEC8 alone as those maybe ready to get their first endorsements, but if needed we can add the draft status after next weeks meeting.