### PR TITLE
MAINT: remove unused dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
We don't use any GHA, so this bot is useless atm. 