### PR TITLE
Add IPython endorsement to spec 0007.

### DIFF
--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -10,6 +10,7 @@ author:
 discussion: https://github.com/scipy/scipy/issues/14322
 endorsed-by:
   - scikit-image
+  - ipython
 ---
 
 ## Description


### PR DESCRIPTION
IPython does not expose such API, but I believe contains a few location where we may use it (tests), and show examples of it (in docstrings).

The usage of seeds and reproducibility has often be a challenge for out users – in the terminal and via IPython.

Therefore I think that this is a good step forward for the ecosytems.

A couple of notes:

 - I personally don't like `rng`, I think it is too short and hard to grep for as it get many false positive, but I don't have a better alternative; yes you can use regex or ast-matching search engine, but still. It may be difficult to find if consumer use rng automatically as a metric  automatically

 - I'd love a section for consumers that explicitely state that even when both rng/seed are parameter, it would _still be great_ to compare with library version and call when possible with RNG. Otherwise people will start usign rng only when the older version they supoprt start supporting rng, which delay the whole transition

 - I'll remind that there is a `PendingDeprecationWarning` which is standard and supposed to be used for not yes deprecated stuff.

 - "use `numpy.random.default_rng` to validate", I think "validate" is incorrect, it should be "normalise", validate often returns a boolean, or raise a error, or normaliser may return a different object (unless the passed object is already normal.

 - I think the warning in `transition_to_rng` should include _since which version_ rng is available; if you maintain a library when it will be remove as some consequence but _since when it's available tells you wether you can _start_ doing the change without having version check (and if version check, which version to check for). That's the carrot. The stick is the version in which you will remove; and usually you want to avoid warnign someone of a punition when they haven't done anything yet.

   The common argument against this is "but the warning is show on the current version, so you know the  current version is the one where this started". That is untrue, you leapfrog version or start using a new function, or care about older version.