### PR TITLE
SPEC-0007: rename validate to normalize

### DIFF
--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -26,7 +26,7 @@ We recommend:
 We suggest implementing these principles by:
 
 - deprecating uses of an existing seed argument (commonly `random_state` or `seed`) in favor of a consistent `rng` argument,
-- using `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`[^no-RandomState], and
+- using `numpy.random.default_rng` to normalize the `rng` argument and instantiate a `Generator`[^no-RandomState], and
 - deprecating the use of `numpy.random.seed` to control the random state.
 
 We are primarily concerned with API uniformity, but also encourage libraries to move towards using [NumPy pseudo-random `Generator`s](https://numpy.org/doc/stable/reference/random/generator.html) because:
@@ -65,7 +65,7 @@ Endorsement of this SPEC means that a project considers the standardization and 
 To adopt this SPEC, a project should:
 
 - deprecate the use of `random_state`/`seed` arguments in favor of an `rng` argument in all functions where users need to control pseudo-random number generation,
-- use `numpy.random.default_rng` to validate the `rng` argument and instantiate a `Generator`, and
+- use `numpy.random.default_rng` to normalize the `rng` argument and instantiate a `Generator`, and
 - deprecate the use of `numpy.random.seed` to control the random state.
 
 #### Badges
@@ -88,7 +88,7 @@ The [deprecation strategy](https://github.com/scientific-python/specs/pull/180#i
 **Initially**, accept both `rng` and the existing `random_state`/`seed`/`...` keyword arguments.
 
 - If both are specified by the user, raise an error.
-- If `rng` is passed by keyword, validate it with `np.random.default_rng()` and use it to generate random numbers as needed.
+- If `rng` is passed by keyword, normalize it with `np.random.default_rng()` and use it to generate random numbers as needed.
 - If `random_state`/`seed`/`...` is specified (by keyword or position, if allowed), preserve existing behavior.
 
 **After `rng` becomes available** in all releases within the support window suggested by SPEC 0, emit warnings as follows:

--- a/spec-0007/transition_to_rng.py
+++ b/spec-0007/transition_to_rng.py
@@ -134,7 +134,7 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
                     message = (
                         f"Positional use of `{NEW_NAME}` (formerly known as "
                         f"`{old_name}`) is still allowed, but the behavior is "
-                        "changing: the argument will be validated using "
+                        "changing: the argument will be normalized using "
                         f"`np.random.default_rng` beginning in SciPy {end_version}, "
                         "and the resulting `Generator` will be used to generate "
                         "random numbers."
@@ -142,7 +142,7 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
                     warnings.warn(message, FutureWarning, stacklevel=2)
 
             elif as_new_kwarg:  # no warnings; this is the preferred use
-                # After the removal of the decorator, validation with
+                # After the removal of the decorator, normalized with
                 # np.random.default_rng will be done inside the decorated function
                 kwargs[NEW_NAME] = np.random.default_rng(kwargs[NEW_NAME])
 
@@ -164,7 +164,7 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None):
 
 # Example usage of _prepare_rng decorator.
 
-# Suppose a library uses a custom random state validation function, such as
+# Suppose a library uses a custom random state normalisation function, such as
 from scipy._lib._util import check_random_state
 
 # https://github.com/scipy/scipy/blob/94532e74b902b569bfad504866cb53720c5f4f31/scipy/_lib/_util.py#L253
@@ -193,7 +193,7 @@ def library_function(arg1, rng=None, arg2=0):
     return rng.random() * arg1 + arg2
 
 
-# At the end of the deprecation period, remove the decorator, and validate
+# At the end of the deprecation period, remove the decorator, and  normalize
 # `rng` with` np.random.default_rng`.
 def library_function(arg1, rng=None, arg2=0):
     rng = np.random.default_rng(rng)


### PR DESCRIPTION
Valiate usually convey a notion of boolean or raising an error, here we are normalizing because we are rreturning potentially a different object.