### PR TITLE
NumPy project endorses SPEC 6

### DIFF
--- a/spec-0006/index.md
+++ b/spec-0006/index.md
@@ -11,6 +11,7 @@ discussion: https://discuss.scientific-python.org/t/spec-6-keys-to-the-castle
 endorsed-by:
   - ipython
   - networkx
+  - numpy
   - scikit-image
 ---
 


### PR DESCRIPTION
After an extensive review and discussion with the maintainers and developer community, the NumPy Steering Council came to a consensus on endorsing SPEC 6.