### PR TITLE
NumPy project endorses SPEC 7

### DIFF
--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -10,6 +10,7 @@ author:
 discussion: https://github.com/scipy/scipy/issues/14322
 endorsed-by:
   - ipython
+  - numpy
   - scikit-image
   - scipy
 ---


### PR DESCRIPTION
After an extensive review and discussion with the community, the NumPy Steering Council came to a consensus on endorsing SPEC 7