### PR TITLE
NumPy project endorses SPEC 8

### DIFF
--- a/spec-0008/index.md
+++ b/spec-0008/index.md
@@ -12,6 +12,7 @@ author:
 discussion: https://discuss.scientific-python.org/t/spec-8-supply-chain-security
 endorsed-by:
   - networkx
+  - numpy
   - scikit-image
 ---
 


### PR DESCRIPTION
After a review and discussion with the maintainers and developer community, the NumPy Steering Council came to a consensus on endorsing SPEC 8