### PR TITLE
Restructure SPEC comments

### DIFF
--- a/purpose-and-process/_index.md
+++ b/purpose-and-process/_index.md
@@ -54,7 +54,7 @@ reviewing, discussing, implementing, and endorsing SPEC documents.
 SPEC Steering Committee
 : The [Steering Committee](/specs/steering-committee) leads the SPEC project and
 manages the SPEC process including moderating
-the [SPECs discussion forum](https://discuss.scientific-python.org/c/specs/6),
+the [SPECs discussion forum](https://discuss.scientific-python.org/c/specs/),
 accepting SPEC documents, and maintaining the SPEC process documents.
 
 SPEC Process
@@ -79,10 +79,7 @@ The SPEC documents are converted to HTML by code in the
 [scientific-python.org repository](https://github.com/scientific-python/scientific-python.org/) using
 [Hugo](https://gohugo.io/) and deployed to
 [https://scientific-python.org/specs/](https://scientific-python.org/specs/).
-Each SPEC has a corresponding
-[discussion](https://discuss.scientific-python.org/c/specs/accepted/15)
-with the same title, where anyone can comment, ask questions, or vote on
-existing comments.
+Each SPEC has two corresponding discussions: one under [SPECS → Ideas](https://discuss.scientific-python.org/c/specs/ideas), where the SPEC committee discussed its viability, and another under [SPECS → Web Comments](https://discuss.scientific-python.org/c/specs/web-comments), where public comments from https://scientific-python.org/specs are stored.
 
 ## Implementation
 
@@ -122,9 +119,10 @@ The decision to **accept** a SPEC is made by the Steering Committee,
 at which point it is added to the main branch of the [SPEC
 repository](https://github.com/scientific-python/specs), clearly
 labeled as a draft.
-Proposed SPECs are accepted once (a) the draft is written to clearly
-explain the area of common concern and a general approach to a shared
-solution and (b) there are contributors (from at least two Core
+Proposed SPECs are accepted once (a) there is agreement that the SPEC
+concept is applicable to the ecosystem, (b) a draft pull request is
+written to clearly explain the area of common concern and a general
+approach to a shared solution, and (c) there are contributors (from at least two Core
 Projects) interested in working on the new SPEC and in championing it
 to their projects as well as the larger community.
 Additional details may be found in [Steering Committee
@@ -248,11 +246,11 @@ the idea** by doing one or more of the following:
 2. discuss the idea with at least one other member of the ecosystem, or
 3. create a minimal, proof of concept prototype.
 
-Before a proposed SPEC can be accepted, the idea must be discussed on
-the discussion forum under the [`SPECS/Ideas`
-topic](https://discuss.scientific-python.org/c/specs/ideas/9).
-Thereafter a new SPEC document must be submitted as a pull request to
-the [SPEC repository](https://github.com/scientific-python/specs).
+Before a proposed SPEC can be accepted:
+
+1. The idea must be proposed on the discussion forum under the [`SPECS/Ideas`
+   topic](https://discuss.scientific-python.org/c/specs/ideas/9).
+2. A draft SPEC document must be submitted via pull request to the [SPEC repository](https://github.com/scientific-python/specs).
 
 Use the `quickstart.py` script to create the new SPEC document.
 Located at the top-level of the [SPEC
@@ -262,8 +260,6 @@ appropriately named with a basic template for you to complete (e.g.,
 `spec-0000/index.md`).
 Once the SPEC is in reasonable shape, file a pull request against the
 [SPEC repository](https://github.com/scientific-python/specs).
-The Steering Committee then considers the SPEC as presented in the
-pull request and will provide additional guidance.
 
 ## Notes
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -27,7 +27,6 @@ number: {number}
 date: {now.strftime("%Y-%m-%d")}
 author:
   - "{author} <{email}>"
-discussion: https://discuss.scientific-python.org/t/
 is-draft: true
 endorsed-by:
 ---

--- a/spec-0000/index.md
+++ b/spec-0000/index.md
@@ -13,7 +13,6 @@ author:
   - "Ross Barnowski <rossbar@berkeley.edu>"
   - "Stéfan van der Walt <stefanv@berkeley.edu>"
   - "Thomas A Caswell <tcaswell@gmail.com>"
-discussion: https://discuss.scientific-python.org/t/spec-0-minimum-supported-versions/33
 endorsed-by:
   - ipython
   - matplotlib

--- a/spec-0001/index.md
+++ b/spec-0001/index.md
@@ -7,7 +7,6 @@ author:
   - "Jon Crall <jon.crall@kitware.com>"
   - "Dan Schult <dschult@colgate.edu>"
   - "Jarrod Millman <millman@berkeley.edu>"
-discussion: https://discuss.scientific-python.org/t/spec-1-lazy-loading-for-submodules/25
 endorsed-by:
   - ipython
   - networkx

--- a/spec-0002/index.md
+++ b/spec-0002/index.md
@@ -5,7 +5,6 @@ date: 2021-12-16
 author:
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Aditi Juneja <aditijuneja7@gmail.com>"
-discussion:
 is-draft: true
 endorsed-by:
 ---

--- a/spec-0003/index.md
+++ b/spec-0003/index.md
@@ -5,7 +5,6 @@ date: 2022-02-14
 author:
   - "Juanita Gomez <juanitagomezr2112@gmail.com>"
   - "Sarah Kaiser <sckaiser@sckaiser.com>"
-discussion: https://discuss.scientific-python.org/t/spec-3-accessibility/63
 is-draft: true
 endorsed-by:
 ---

--- a/spec-0004/index.md
+++ b/spec-0004/index.md
@@ -10,8 +10,6 @@ author:
   - "Mridul Seth <mail@mriduls.com>"
   - "Olivier Grisel <olivier.grisel@ensta.org>"
   - "Tim Head <betatim@gmail.com>"
-
-discussion: https://discuss.scientific-python.org/t/spec-4-nightly-wheels/474
 endorsed-by:
   - ipython
   - matplotlib

--- a/spec-0005/index.md
+++ b/spec-0005/index.md
@@ -8,7 +8,6 @@ author:
   - "Ryan May <rmay@ucar.edu>"
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Brigitta Sipőcz <brigitta.sipocz@gmail.com>"
-discussion: https://discuss.scientific-python.org/t/spec-5-ci-best-practices/507
 is-draft: true
 endorsed-by:
 ---

--- a/spec-0006/index.md
+++ b/spec-0006/index.md
@@ -7,7 +7,6 @@ author:
   - "Jarrod Millman <millman@berkeley.edu>"
   - "Pamphile Roy <roy.pamphile@gmail.com>"
   - "Lars Grüter <lagru@mailbox.org>"
-discussion: https://discuss.scientific-python.org/t/spec-6-keys-to-the-castle
 endorsed-by:
   - ipython
   - networkx

--- a/spec-0007/index.md
+++ b/spec-0007/index.md
@@ -7,7 +7,6 @@ author:
   - "Sebastian Berg <sebastianb@nvidia.com>"
   - "Pamphile Roy <roy.pamphile@gmail.com>"
   - "Matt Haberland <mhaberla@calpoly.edu>"
-discussion: https://github.com/scipy/scipy/issues/14322
 endorsed-by:
   - ipython
   - numpy

--- a/spec-0008/index.md
+++ b/spec-0008/index.md
@@ -9,7 +9,6 @@ author:
   - "Seth Larson <sethmichaellarson@gmail.com>"
   - "Lars Grüter <lagru@mailbox.org>"
   - "Jarrod Millman <millman@berkeley.edu>"
-discussion: https://discuss.scientific-python.org/t/spec-8-supply-chain-security
 endorsed-by:
   - networkx
   - numpy

--- a/spec-0009/index.md
+++ b/spec-0009/index.md
@@ -8,7 +8,6 @@ author:
   - "Daniel McCloy <dan@mccloy.info>"
   - "Matt Haberland <mhaberla@calpoly.edu>"
   - "Jarrod Millman <millman@berkeley.edu>"
-discussion: https://discuss.scientific-python.org/t/spec-9-governance/1229
 is-draft: true
 endorsed-by:
 ---


### PR DESCRIPTION
In accordance with
https://github.com/scientific-python/specs/issues/369

- Remove originating discussion link from header
- Update specs and process to point to the two relevant discussion categories