### PR TITLE
scikit-learn endorsment of SPEC1

### DIFF
--- a/spec-0001/index.md
+++ b/spec-0001/index.md
@@ -12,6 +12,7 @@ endorsed-by:
   - networkx
   - numpy
   - scikit-image
+  - scikit-learn
   - scipy
 shortcutDepth: 3
 ---


### PR DESCRIPTION
With the merge of https://github.com/scikit-learn/scikit-learn/pull/29793, I can safely state the scikit-learn community is endorsing the SPEC1