### PR TITLE
Add PySAL and Scikit-HEP domain stack metapackages

### DIFF
--- a/core-projects/_index.md
+++ b/core-projects/_index.md
@@ -10,9 +10,10 @@ endorsed-by:
 
 ## Description
 
-Core Projects are depended upon by most of the other projects,
+Core Projects are depended upon by many of the other projects,
 and often provide basic data structures, drawing primitives,
-or implementations of fundamental algorithms.
+implementations of fundamental algorithms, or are metapackages for a subecosystem
+representing a particular scientific field or domain.
 Due to their central position in the ecosystem, the policies, practices, and tooling
 used by the Core Projects are widely seen by the ecosystem
 and impact many other projects.
@@ -43,9 +44,10 @@ scientific Python ecosystem overlaps with the PyData ecosystem---which has a
 stronger focus on solving problems in industry.
 
 Core Projects are **widely used in the scientific Python ecosystem**.
-They are depended upon by most of the other projects,
+They are depended upon by many of the other projects,
 often providing basic data structures, drawing primitives,
-or implementations of fundamental algorithms.
+implementations of fundamental algorithms, or are metapackages for a subecosystem
+representing a particular scientific field or domain.
 
 Core Projects are **developed using shared community practices**.
 They have a version control system, a bug tracker, a

--- a/core-projects/_index.md
+++ b/core-projects/_index.md
@@ -10,10 +10,10 @@ endorsed-by:
 
 ## Description
 
-Core Projects are depended upon by many of the other projects,
+Core Projects are depended upon by many other projects,
 and often provide basic data structures, drawing primitives,
-implementations of fundamental algorithms, or are metapackages for a subecosystem
-representing a particular scientific field or domain.
+implementations of fundamental algorithms, or are metapackages
+that represent a particular scientific field.
 Due to their central position in the ecosystem, the policies, practices, and tooling
 used by the Core Projects are widely seen by the ecosystem
 and impact many other projects.
@@ -44,10 +44,10 @@ scientific Python ecosystem overlaps with the PyData ecosystem---which has a
 stronger focus on solving problems in industry.
 
 Core Projects are **widely used in the scientific Python ecosystem**.
-They are depended upon by many of the other projects,
+They are depended upon by many other projects,
 often providing basic data structures, drawing primitives,
-implementations of fundamental algorithms, or are metapackages for a subecosystem
-representing a particular scientific field or domain.
+implementations of fundamental algorithms, or are metapackages
+that represent a particular scientific field.
 
 Core Projects are **developed using shared community practices**.
 They have a version control system, a bug tracker, a

--- a/core-projects/pysal.md
+++ b/core-projects/pysal.md
@@ -1,0 +1,11 @@
+---
+title: "PySAL"
+avatar: https://avatars.githubusercontent.com/u/3769919
+homepage: https://pysal.org
+repository: https://github.com/pysal/pysal
+pypi: https://pypi.org/project/pysal
+libraries-io: https://libraries.io/pypi/pysal
+license: https://github.com/pysal/pysal/blob/main/LICENSE.txt
+license-type: 3-clause BSD
+contact: sjsrey
+---

--- a/core-projects/scikit-hep.md
+++ b/core-projects/scikit-hep.md
@@ -1,0 +1,11 @@
+---
+title: "Scikit-HEP"
+avatar: https://avatars.githubusercontent.com/u/23454624
+homepage: https://scikit-hep.org
+repository: https://github.com/scikit-hep/scikit-hep
+pypi: https://pypi.org/project/scikit-hep
+libraries-io: https://libraries.io/pypi/scikit-hep
+license: https://github.com/scikit-hep/scikit-hep/blob/main/LICENSE
+license-type: 3-clause BSD
+contact: matthewfeickert
+---


### PR DESCRIPTION
This was discussed (and tentatively approved) at the last monthly SPEC meeting. I've tried to minimally edit the Core Project description to reflect the idea that they may include domain stacks that have meta-packages for particular scientific fields or domains. These meta-packages themselves may or may not be imported by a large number of projects, but often include useful packages which are. They also reflect large and important user communities in the scientific Python ecosystem. My goal is merge this PR by April 10th.

@sjsrey @matthewfeickert It would be great if you could review the PR to make sure I got the details correct. Please ask other members of your community to provide feedback or thumbs up.

It would also be great to get feedback and thumbs up from the SPEC steering committee. For committee members who missed the last meeting, it would be great to get feedback or questions.