### PR TITLE
add PR template for new SPECs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--- Thanks for proposing a new SPEC! Make sure your PR title is descriptive and short. -->
+
+## Attestation
+
+- [ ] I have read and understood the [SPEC Purpose and Process](https://scientific-python.org/specs/purpose-and-process/) guidelines
+
+## Description
+<!--- Please summarize the purpose of this new SPEC, in 1-3 sentences. -->
+
+## Link to SPEC Committee's "viability" discussion thread (required)
+<!--
+Insert a link to this proposal's initial viability discussion thread in
+https://discuss.scientific-python.org/c/specs/ideas
+-->
+
+## Link to "public comments" discussion thread (required)
+<!--
+insert a link to this proposal's community-wide discussion thread in
+https://discuss.scientific-python.org/c/specs/web-comments
+-->
+
+## Description of (or link to) exploratory discussions/POCs (optional)
+<!--
+SPEC guidelines suggest a first step of one of the following:
+
+1. discuss the idea with at least one project in the ecosystem,
+1. discuss the idea with at least one other member of the ecosystem, or
+1. create a minimal, proof of concept (POC) prototype.
+
+(see https://scientific-python.org/specs/purpose-and-process/#new-spec-proposals).
+In this field, include a description of those preliminary steps and/or links to public discussions or POCs.
+-->


### PR DESCRIPTION
@jarrodmillman proposed this idea at the Summit and I volunteered to implement. However, I'm actually not sure it's a good idea to merge this, because:

1. The template's current location and filename should mean that it shows up on every new PR; however, this repo gets PRs other than new SPEC proposals (e.g., to update draft SPECs), and the PR template won't be relevant for those.
2. Although GH allows a repo to have multiple PR templates, they aren't selectable through the UI like issue templates are; they require manually adding URL query parameters like `?template=propose_a_new_spec.md`. (They also require storing the templates in `.github/PULL_REQUEST_TEMPLATE/`, and if one does so, new PRs opened through the UI will not use any template at all.)

It might be possible to hack a solution by making a default template at `.github/pull_request_template.md` that includes relative links to the various templates using URL query parameters ([example here](https://stackoverflow.com/a/75030350)), but that feels a bit brittle / over-engineered. LMK if there's appetite for that approach though, and I can give it a shot.

Other note: while Issue templates can be defined in YAML files and include built-in validation, PR templates cannot. Validation would have to use a GH Action ([example here](https://github.com/orgs/community/discussions/84771#discussioncomment-8039595)).