### PR TITLE
BUG: fix spec0 script bug

### DIFF
--- a/spec-0000/SPEC0_versions.py
+++ b/spec-0000/SPEC0_versions.py
@@ -59,7 +59,7 @@ def get_release_dates(package, support_time=plus24):
         try:
             version = Version(ver)
         except InvalidVersion as e:
-            print(f"Error: '{ver}' is an invalid version. Reason: {e}")
+            print(f"Error: '{ver}' is an invalid version for '{package}'. Reason: {e}")
             continue
 
         if version.is_prerelease or version.micro != 0:

--- a/spec-0000/SPEC0_versions.py
+++ b/spec-0000/SPEC0_versions.py
@@ -60,6 +60,7 @@ def get_release_dates(package, support_time=plus24):
             version = Version(ver)
         except InvalidVersion as e:
             print(f"Error: '{ver}' is an invalid version. Reason: {e}")
+            continue
 
         if version.is_prerelease or version.micro != 0:
             continue


### PR DESCRIPTION
The ruff changes introduced a bug in efc1f7624c46e68054d1d1f2f2a29c71f670ab82 by removing the `continue` and we haven't run the script since then to spot the issue.