### PR TITLE
Fix START node for SPECs purpose flowchart

### DIFF
--- a/purpose-and-process/_index.md
+++ b/purpose-and-process/_index.md
@@ -120,7 +120,7 @@ its development and implementation:
 ```mermaid
 graph LR
 
-START[ ]--> |Propose| A[Accept]
+START--> |Propose| A[Accept]
 A--> |Develop| B[Publish]
 B--> |Canvass| C[Endorse]
 C--> |Recommend| D[Adopt]
@@ -129,8 +129,6 @@ click A callback "Steering Committee Action"
 click B callback "Author Action"
 click C callback "Core Project Action"
 click D callback "Ecosystem Action"
-
-style START fill:#FFFFFF, stroke:#FFFFFF;
 
 ```
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
I've removed an unnecessary style and empty label from the Mermaid flowchart on the SPECs Purpose and Process page. See screenshot in https://github.com/scientific-python/specs/issues/396#issue-3130461887 and a fix in https://github.com/scientific-python/specs/issues/396#issuecomment-3663579126. This PR partially addresses an issue I noticed there; the styling for Mermaid diagrams to suit dark mode colours is being discussed in https://github.com/scientific-python/scientific-python-hugo-theme/issues/593.

<table>
<tr>
 <td> <p align="center"> Before
 <td> <p align="center"> After


<tr>
 <td> <br><img width="2184" height="225" alt="image" src="https://github.com/user-attachments/assets/d7590aab-6a53-4161-b42a-6c94dbe87d2b" /><br><br>
 <td> <br><img width="2184" height="225" alt="image" src="https://github.com/user-attachments/assets/4eeda77a-2456-44a1-abc9-40a74ce72fe3" /><br><br>
</table>
